### PR TITLE
Initial speakers

### DIFF
--- a/Editor/Tests/Engine/SerializationTest.cs
+++ b/Editor/Tests/Engine/SerializationTest.cs
@@ -240,10 +240,11 @@ namespace Exodrifter.Rumor.Test.Engine
 		[Test]
 		public void SerializeAdd()
 		{
+			var scope = new Scope();
 			var a = new Add("add");
 			var b = Reserialize(a);
 
-			Assert.AreEqual(a.text, b.text);
+			Assert.AreEqual(a.EvaluateText(scope), b.EvaluateText(scope));
 		}
 
 		/// <summary>
@@ -466,7 +467,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			// Check to see if serializing during execution works
 			rumor = Reserialize(rumor);
 
-			Assert.AreEqual("How are you?", rumor.State.Dialog);
+			Assert.AreEqual("How are you?", rumor.State.Dialog[RumorState.NARRATOR]);
 
 			yield = rumor.Run();
 			yield.MoveNext();
@@ -543,7 +544,7 @@ namespace Exodrifter.Rumor.Test.Engine
 		public void SerializeRumorStateDialog()
 		{
 			var a = new RumorState();
-			a.SetDialog("dialog");
+			a.SetDialog(null, "dialog");
 			var b = Reserialize(a);
 
 			Assert.AreEqual(a.Dialog, b.Dialog);

--- a/Editor/Tests/Engine/SerializationTest.cs
+++ b/Editor/Tests/Engine/SerializationTest.cs
@@ -467,7 +467,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			// Check to see if serializing during execution works
 			rumor = Reserialize(rumor);
 
-			Assert.AreEqual("How are you?", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("How are you?", rumor.State.Dialog[null]);
 
 			yield = rumor.Run();
 			yield.MoveNext();
@@ -547,7 +547,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			a.SetDialog(null, "dialog");
 			var b = Reserialize(a);
 
-			Assert.AreEqual(a.Dialog, b.Dialog);
+			Assert.AreEqual(a.Dialog[null], b.Dialog[null]);
 		}
 
 		[Test]

--- a/Editor/Tests/Nodes/AddTest.cs
+++ b/Editor/Tests/Nodes/AddTest.cs
@@ -1,4 +1,5 @@
 ﻿using Exodrifter.Rumor.Nodes;
+using Exodrifter.Rumor.Engine;
 using NUnit.Framework;
 using System.Collections.Generic;
 
@@ -17,7 +18,7 @@ namespace Exodrifter.Rumor.Test.Nodes
 		{
 			var rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("add", rumor.State.Dialog);
+			Assert.AreEqual("add", rumor.State.Dialog[RumorState.NARRATOR]);
 		}
 
 		/// <summary>
@@ -30,25 +31,25 @@ namespace Exodrifter.Rumor.Test.Nodes
 			var rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing add", rumor.State.Dialog);
+			Assert.AreEqual("thing add", rumor.State.Dialog[RumorState.NARRATOR]);
 			
 			// Don't add a space if dialog ends with a space
 			rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing ").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing add", rumor.State.Dialog);
+			Assert.AreEqual("thing add", rumor.State.Dialog[RumorState.NARRATOR]);
 
 			// Don't add a space if dialog ends with a tab
 			rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing\t").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing\tadd", rumor.State.Dialog);
+			Assert.AreEqual("thing\tadd", rumor.State.Dialog[RumorState.NARRATOR]);
 
 			// Don't add a space if dialog ends with a newline
 			rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing\n").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing\nadd", rumor.State.Dialog);
+			Assert.AreEqual("thing\nadd", rumor.State.Dialog[RumorState.NARRATOR]);
 		}
 
 		/// <summary>
@@ -62,8 +63,8 @@ namespace Exodrifter.Rumor.Test.Nodes
 			new Say("thing").Run(rumor).MoveNext();
 			new Add("").Run(rumor).MoveNext();
 
-			// Adding to a say line should automatically add a space
-			Assert.AreEqual("thing", rumor.State.Dialog);
+			// Adding nothing to a say line should do nothing
+			Assert.AreEqual("thing", rumor.State.Dialog[RumorState.NARRATOR]);
 		}
 	}
 }

--- a/Editor/Tests/Nodes/AddTest.cs
+++ b/Editor/Tests/Nodes/AddTest.cs
@@ -1,5 +1,4 @@
 ﻿using Exodrifter.Rumor.Nodes;
-using Exodrifter.Rumor.Engine;
 using NUnit.Framework;
 using System.Collections.Generic;
 
@@ -18,7 +17,7 @@ namespace Exodrifter.Rumor.Test.Nodes
 		{
 			var rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("add", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("add", rumor.State.Dialog[null]);
 		}
 
 		/// <summary>
@@ -31,25 +30,25 @@ namespace Exodrifter.Rumor.Test.Nodes
 			var rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing add", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("thing add", rumor.State.Dialog[null]);
 			
 			// Don't add a space if dialog ends with a space
 			rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing ").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing add", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("thing add", rumor.State.Dialog[null]);
 
 			// Don't add a space if dialog ends with a tab
 			rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing\t").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing\tadd", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("thing\tadd", rumor.State.Dialog[null]);
 
 			// Don't add a space if dialog ends with a newline
 			rumor = new Rumor.Engine.Rumor(new List<Node>());
 			new Say("thing\n").Run(rumor).MoveNext();
 			new Add("add").Run(rumor).MoveNext();
-			Assert.AreEqual("thing\nadd", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("thing\nadd", rumor.State.Dialog[null]);
 		}
 
 		/// <summary>
@@ -64,7 +63,7 @@ namespace Exodrifter.Rumor.Test.Nodes
 			new Add("").Run(rumor).MoveNext();
 
 			// Adding nothing to a say line should do nothing
-			Assert.AreEqual("thing", rumor.State.Dialog[RumorState.NARRATOR]);
+			Assert.AreEqual("thing", rumor.State.Dialog[null]);
 		}
 	}
 }

--- a/Engine/RumorState.cs
+++ b/Engine/RumorState.cs
@@ -12,12 +12,10 @@ namespace Exodrifter.Rumor.Engine
 	[Serializable]
 	public class RumorState : ISerializable
 	{
-		public const string NARRATOR = "_narrator";
-
 		/// <summary>
 		/// Returns the current dialog.
 		/// </summary>
-		public Dictionary<object, string> Dialog { get; private set; }
+		public LazyDictionary<object, string> Dialog { get; private set; }
 
 		/// <summary>
 		/// Returns a list of choices.
@@ -42,35 +40,30 @@ namespace Exodrifter.Rumor.Engine
 		/// </summary>
 		public void Reset()
 		{
-			Dialog = new Dictionary<object, string>();
+			Dialog = new LazyDictionary<object, string>();
 			Choices = new List<string>();
 			Consequences = new List<List<Node>>();
 		}
 
 		/// <summary>
-		/// Sets the dialog for the state. If the speaker is null, then the
-		/// <see cref="RumorState.NARRATOR"/> is used instead.
+		/// Sets the dialog for the state.
 		/// </summary>
 		/// <param name="speaker">The speaker of the dialog.</param>
 		/// <param name="dialog">The dialog to set.</param>
 		public void SetDialog(object speaker, string dialog)
 		{
 			Dialog.Clear();
-			Dialog[speaker ?? NARRATOR] = dialog;
+			Dialog[speaker] = dialog;
 		}
 
 		/// <summary>
 		/// Adds to the dialog for the state.
 		/// </summary>
+		/// <param name="speaker">The speaker of the dialog.</param>
 		/// <param name="dialog">The dialog to add.</param>
-		public void AddDialog(object character, string dialog)
+		public void AddDialog(object speaker, string dialog)
 		{
-			if (Dialog.ContainsKey(character)) {
-				Dialog[character ?? NARRATOR] += dialog;
-			}
-			else {
-				Dialog[character ?? NARRATOR] = dialog;
-			}
+			Dialog[speaker] += dialog;
 		}
 
 		/// <summary>
@@ -105,7 +98,7 @@ namespace Exodrifter.Rumor.Engine
 
 		public RumorState(SerializationInfo info, StreamingContext context)
 		{
-			Dialog = info.GetValue<Dictionary<object,string>>("dialog");
+			Dialog = info.GetValue<LazyDictionary<object,string>>("dialog");
 			Choices = info.GetValue<List<string>>("choices");
 			Consequences = info.GetValue<List<List<Node>>>("consequences");
 		}
@@ -113,7 +106,7 @@ namespace Exodrifter.Rumor.Engine
 		public void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
-			info.AddValue<Dictionary<object,string>>("dialog", Dialog);
+			info.AddValue<LazyDictionary<object,string>>("dialog", Dialog);
 			info.AddValue<List<string>>("choices", Choices);
 			info.AddValue<List<List<Node>>>("consequences", Consequences);
 		}

--- a/Engine/RumorState.cs
+++ b/Engine/RumorState.cs
@@ -12,10 +12,12 @@ namespace Exodrifter.Rumor.Engine
 	[Serializable]
 	public class RumorState : ISerializable
 	{
+		public const string NARRATOR = "_narrator";
+
 		/// <summary>
 		/// Returns the current dialog.
 		/// </summary>
-		public string Dialog { get; private set; }
+		public Dictionary<object, string> Dialog { get; private set; }
 
 		/// <summary>
 		/// Returns a list of choices.
@@ -40,27 +42,35 @@ namespace Exodrifter.Rumor.Engine
 		/// </summary>
 		public void Reset()
 		{
-			Dialog = "";
+			Dialog = new Dictionary<object, string>();
 			Choices = new List<string>();
 			Consequences = new List<List<Node>>();
 		}
 
 		/// <summary>
-		/// Sets the dialog for the state.
+		/// Sets the dialog for the state. If the speaker is null, then the
+		/// <see cref="RumorState.NARRATOR"/> is used instead.
 		/// </summary>
+		/// <param name="speaker">The speaker of the dialog.</param>
 		/// <param name="dialog">The dialog to set.</param>
-		public void SetDialog(string dialog)
+		public void SetDialog(object speaker, string dialog)
 		{
-			Dialog = dialog ?? "";
+			Dialog.Clear();
+			Dialog[speaker ?? NARRATOR] = dialog;
 		}
 
 		/// <summary>
 		/// Adds to the dialog for the state.
 		/// </summary>
 		/// <param name="dialog">The dialog to add.</param>
-		public void AddDialog(string dialog)
+		public void AddDialog(object character, string dialog)
 		{
-			Dialog += dialog;
+			if (Dialog.ContainsKey(character)) {
+				Dialog[character ?? NARRATOR] += dialog;
+			}
+			else {
+				Dialog[character ?? NARRATOR] = dialog;
+			}
 		}
 
 		/// <summary>
@@ -95,7 +105,7 @@ namespace Exodrifter.Rumor.Engine
 
 		public RumorState(SerializationInfo info, StreamingContext context)
 		{
-			Dialog = info.GetValue<string>("dialog");
+			Dialog = info.GetValue<Dictionary<object,string>>("dialog");
 			Choices = info.GetValue<List<string>>("choices");
 			Consequences = info.GetValue<List<List<Node>>>("consequences");
 		}
@@ -103,7 +113,7 @@ namespace Exodrifter.Rumor.Engine
 		public void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
-			info.AddValue<string>("dialog", Dialog);
+			info.AddValue<Dictionary<object,string>>("dialog", Dialog);
 			info.AddValue<List<string>>("choices", Choices);
 			info.AddValue<List<List<Node>>>("consequences", Consequences);
 		}

--- a/Engine/Scope.cs
+++ b/Engine/Scope.cs
@@ -24,6 +24,11 @@ namespace Exodrifter.Rumor.Engine
 		private readonly Dictionary<string, Value> vars;
 
 		/// <summary>
+		/// The default narrator for nodes to use.
+		/// </summary>
+		public object DefaultSpeaker { get; set; }
+
+		/// <summary>
 		/// Creates a new scope.
 		/// </summary>
 		/// <param name="parent">
@@ -325,6 +330,8 @@ namespace Exodrifter.Rumor.Engine
 			for (int i = 0; i < keys.Count; ++i) {
 				vars.Add(keys[i], values[i]);
 			}
+
+			DefaultSpeaker = info.GetValue<object>("defaultSpeaker");
 		}
 
 		void ISerializable.GetObjectData
@@ -340,6 +347,8 @@ namespace Exodrifter.Rumor.Engine
 
 			info.AddValue<List<string>>("keys", keys);
 			info.AddValue<List<Value>>("values", values);
+
+			info.AddValue<object>("defaultSpeaker", DefaultSpeaker);
 		}
 
 		#endregion

--- a/Examples/RumorCodeExample.cs
+++ b/Examples/RumorCodeExample.cs
@@ -54,8 +54,8 @@ namespace Example.Exodrifter
 					num++;
 				}
 			}
-			else {
-				text.text = rumor.State.Dialog;
+			else if (rumor.State.Dialog.ContainsKey(RumorState.NARRATOR)) {
+				text.text = rumor.State.Dialog[RumorState.NARRATOR];
 			}
 
 			rumor.Update(Time.deltaTime);

--- a/Examples/RumorCodeExample.cs
+++ b/Examples/RumorCodeExample.cs
@@ -18,23 +18,23 @@ namespace Example.Exodrifter
 
 		void Awake()
 		{
-			var n = "Narrator";
 			rumor = new Rumor(new List<Node>() {
 				new Label("start", new List<Node>() {
-					new Say(n, "Hi!"),
-					new Say(n, "Is this working?"),
+					new Say("Hi!"),
+					new Say("Is this working?"),
 					new Choice("Yes!", new List<Node>() {
-						new Say(n, "Great!"),
+						new Say("Great!"),
 					}),
 					new Choice("No.", new List<Node>() {
-						new Say(n, "Darn..."),
+						new Say("Darn..."),
 						new Pause(0.5f),
-						new Add(n, "Maybe next time."),
+						new Add("Maybe next time."),
 					}),
 				}),
 				new Say("Well, thanks for stopping by!"),
 				new Say("See you next time!"),
 			});
+			rumor.Scope.DefaultSpeaker = "Narrator";
 
 			StartCoroutine(rumor.Run());
 		}

--- a/Examples/RumorCodeExample.cs
+++ b/Examples/RumorCodeExample.cs
@@ -18,17 +18,18 @@ namespace Example.Exodrifter
 
 		void Awake()
 		{
+			var n = "Narrator";
 			rumor = new Rumor(new List<Node>() {
 				new Label("start", new List<Node>() {
-					new Say("Hi!"),
-					new Say("Is this working?"),
+					new Say(n, "Hi!"),
+					new Say(n, "Is this working?"),
 					new Choice("Yes!", new List<Node>() {
-						new Say("Great!"),
+						new Say(n, "Great!"),
 					}),
 					new Choice("No.", new List<Node>() {
-						new Say("Darn..."),
+						new Say(n, "Darn..."),
 						new Pause(0.5f),
-						new Add("Maybe next time."),
+						new Add(n, "Maybe next time."),
 					}),
 				}),
 				new Say("Well, thanks for stopping by!"),
@@ -55,7 +56,7 @@ namespace Example.Exodrifter
 				}
 			}
 			else {
-				text.text = rumor.State.Dialog[null];
+				text.text = rumor.State.Dialog["Narrator"];
 			}
 
 			rumor.Update(Time.deltaTime);

--- a/Examples/RumorCodeExample.cs
+++ b/Examples/RumorCodeExample.cs
@@ -54,8 +54,8 @@ namespace Example.Exodrifter
 					num++;
 				}
 			}
-			else if (rumor.State.Dialog.ContainsKey(RumorState.NARRATOR)) {
-				text.text = rumor.State.Dialog[RumorState.NARRATOR];
+			else {
+				text.text = rumor.State.Dialog[null];
 			}
 
 			rumor.Update(Time.deltaTime);

--- a/Examples/RumorScriptExample.cs
+++ b/Examples/RumorScriptExample.cs
@@ -18,21 +18,21 @@ namespace Example.Exodrifter
 		void Awake()
 		{
 			rumor = new Rumor(new RumorCompiler().Compile(@"
-$ n = ""Narrator""
 label start:
-	say n ""Hi!""
-	say n ""Is this working?""
+	say ""Hi!""
+	say ""Is this working?""
 
 	choice ""Yes!"":
-		say n ""Great!""
+		say ""Great!""
 	choice ""No."":
-		say n ""Darn...""
+		say ""Darn...""
 		pause 0.5
-		add n ""Maybe next time.""
+		add ""Maybe next time.""
 
-say n ""Well, thanks for stopping by!""
-say n ""See you next time!""
+say ""Well, thanks for stopping by!""
+say ""See you next time!""
 "));
+			rumor.Scope.DefaultSpeaker = "Narrator";
 
 			StartCoroutine(rumor.Run());
 		}

--- a/Examples/RumorScriptExample.cs
+++ b/Examples/RumorScriptExample.cs
@@ -18,19 +18,20 @@ namespace Example.Exodrifter
 		void Awake()
 		{
 			rumor = new Rumor(new RumorCompiler().Compile(@"
+$ n = ""Narrator""
 label start:
-	say ""Hi!""
-	say ""Is this working?""
+	say n ""Hi!""
+	say n ""Is this working?""
 
 	choice ""Yes!"":
-		say ""Great!""
+		say n ""Great!""
 	choice ""No."":
-		say ""Darn...""
+		say n ""Darn...""
 		pause 0.5
-		add ""Maybe next time.""
+		add n ""Maybe next time.""
 
-say ""Well, thanks for stopping by!""
-say ""See you next time!""
+say n ""Well, thanks for stopping by!""
+say n ""See you next time!""
 "));
 
 			StartCoroutine(rumor.Run());
@@ -53,7 +54,7 @@ say ""See you next time!""
 				}
 			}
 			else {
-				text.text = rumor.State.Dialog[null];
+				text.text = rumor.State.Dialog["Narrator"];
 			}
 
 			rumor.Update(Time.deltaTime);

--- a/Examples/RumorScriptExample.cs
+++ b/Examples/RumorScriptExample.cs
@@ -52,8 +52,8 @@ say ""See you next time!""
 					num++;
 				}
 			}
-			else if (rumor.State.Dialog.ContainsKey(RumorState.NARRATOR)) {
-				text.text = rumor.State.Dialog[RumorState.NARRATOR];
+			else {
+				text.text = rumor.State.Dialog[null];
 			}
 
 			rumor.Update(Time.deltaTime);

--- a/Examples/RumorScriptExample.cs
+++ b/Examples/RumorScriptExample.cs
@@ -52,8 +52,8 @@ say ""See you next time!""
 					num++;
 				}
 			}
-			else {
-				text.text = rumor.State.Dialog;
+			else if (rumor.State.Dialog.ContainsKey(RumorState.NARRATOR)) {
+				text.text = rumor.State.Dialog[RumorState.NARRATOR];
 			}
 
 			rumor.Update(Time.deltaTime);

--- a/Expressions/LiteralExpression.cs
+++ b/Expressions/LiteralExpression.cs
@@ -37,6 +37,11 @@ namespace Exodrifter.Rumor.Expressions
 			value = new BoolValue(b);
 		}
 
+		public LiteralExpression(object obj)
+		{
+			value = new ObjectValue(obj);
+		}
+
 		public override Value Evaluate(Scope scope)
 		{
 			return value;

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -371,8 +371,20 @@ namespace Exodrifter.Rumor.Lang
 		{
 			ExpectNoChildren(line, children);
 
-			string text = Quote(line, ref pos);
-			return new Add(text);
+			var speaker = Expect(line, pos);
+			// TODO: Parse the speaker and expression properly
+			if (speaker == "\"") {
+				var tokens = Slice(line.tokens, pos);
+				var expression = CompileExpression(tokens);
+				return new Say(expression);
+			}
+			else {
+				pos++;
+
+				var tokens = Slice(line.tokens, pos);
+				var expression = CompileExpression(tokens);
+				return new Say(new VariableExpression(speaker), expression);
+			}
 		}
 
 		private Node CompileChoice(LogicalLine line, ref int pos, List<Node> children)
@@ -415,9 +427,20 @@ namespace Exodrifter.Rumor.Lang
 		{
 			ExpectNoChildren(line, children);
 
-			var tokens = Slice(line.tokens, pos);
-			var expression = CompileExpression(tokens);
-			return new Say(expression);
+			var speaker = Expect(line, pos);
+			// TODO: Parse the speaker and expression properly
+			if (speaker == "\"") {
+				var tokens = Slice(line.tokens, pos);
+				var expression = CompileExpression(tokens);
+				return new Say(expression);
+			}
+			else {
+				pos++;
+
+				var tokens = Slice(line.tokens, pos);
+				var expression = CompileExpression(tokens);
+				return new Say(new VariableExpression(speaker), expression);
+			}
 		}
 
 		private Node CompileStatement(LogicalLine line, ref int pos, List<Node> children)

--- a/Nodes/Add.cs
+++ b/Nodes/Add.cs
@@ -54,11 +54,9 @@ namespace Exodrifter.Rumor.Nodes
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
 			var dialog = rumor.State.Dialog;
-			var speaker = this.speaker ?? RumorState.NARRATOR;
 			string text = EvaluateText(rumor);
 
-			if (!dialog.ContainsKey(speaker)
-				|| string.IsNullOrEmpty(dialog[speaker])
+			if (string.IsNullOrEmpty(dialog[speaker])
 				|| dialog[speaker].EndsWith(" ")
 				|| dialog[speaker].EndsWith("\t")
 				|| dialog[speaker].EndsWith("\n")) {

--- a/Nodes/Add.cs
+++ b/Nodes/Add.cs
@@ -1,4 +1,5 @@
 ﻿using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
 using Exodrifter.Rumor.Util;
 using System;
 using System.Collections.Generic;
@@ -10,36 +11,62 @@ namespace Exodrifter.Rumor.Nodes
 	/// Appends additional dialog to the rumor state.
 	/// </summary>
 	[Serializable]
-	public sealed class Add : Node
+	public sealed class Add : Say
 	{
 		/// <summary>
-		/// The text to append to the dialog.
+		/// Creates a new Add node.
 		/// </summary>
-		public readonly string text;
+		/// <param name="text">
+		/// The text to append the dialog with.
+		/// </param>
+		public Add(string text) : base(text) {}
 
 		/// <summary>
 		/// Creates a new Add node.
 		/// </summary>
 		/// <param name="text">
-		/// The text to append to the dialog.
+		/// The expression to append the dialog with.
 		/// </param>
-		public Add(string text)
-		{
-			this.text = text;
-		}
+		public Add(Expression text) : base(text) {}
+
+		/// <summary>
+		/// Creates a new Add node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The text to append the dialog with.
+		/// </param>
+		public Add(object speaker, string text) : base(speaker, text) {}
+
+		/// <summary>
+		/// Creates a new Add node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The expression to append the dialog with.
+		/// </param>
+		public Add(object speaker, Expression text) : base(speaker, text) {}
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
-			string dialog = rumor.State.Dialog;
-			if (string.IsNullOrEmpty(dialog)
-				|| dialog.EndsWith(" ")
-				|| dialog.EndsWith("\t")
-				|| dialog.EndsWith("\n")) {
+			var dialog = rumor.State.Dialog;
+			var speaker = this.speaker ?? RumorState.NARRATOR;
+			string text = EvaluateText(rumor);
 
-				rumor.State.AddDialog(text);
+			if (!dialog.ContainsKey(speaker)
+				|| string.IsNullOrEmpty(dialog[speaker])
+				|| dialog[speaker].EndsWith(" ")
+				|| dialog[speaker].EndsWith("\t")
+				|| dialog[speaker].EndsWith("\n")) {
+
+				rumor.State.AddDialog(speaker, text);
 			}
 			else if (!string.IsNullOrEmpty(text)) {
-				rumor.State.AddDialog(" " + text);
+				rumor.State.AddDialog(speaker, " " + text);
 			}
 			yield return new ForAdvance();
 		}
@@ -49,14 +76,12 @@ namespace Exodrifter.Rumor.Nodes
 		public Add(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
-			text = info.GetValue<string>("text");
 		}
 
 		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
-			info.AddValue<string>("text", text);
 		}
 
 		#endregion

--- a/Nodes/Add.cs
+++ b/Nodes/Add.cs
@@ -38,6 +38,28 @@ namespace Exodrifter.Rumor.Nodes
 		/// <param name="text">
 		/// The text to append the dialog with.
 		/// </param>
+		public Add(Expression speaker, string text) : base(speaker, text) {}
+
+		/// <summary>
+		/// Creates a new Add node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The expression to append the dialog with.
+		/// </param>
+		public Add(Expression speaker, Expression text) : base(speaker, text) {}
+
+		/// <summary>
+		/// Creates a new Add node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The text to append the dialog with.
+		/// </param>
 		public Add(object speaker, string text) : base(speaker, text) {}
 
 		/// <summary>

--- a/Nodes/Add.cs
+++ b/Nodes/Add.cs
@@ -76,6 +76,7 @@ namespace Exodrifter.Rumor.Nodes
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
 			var dialog = rumor.State.Dialog;
+			var speaker = EvaluateSpeaker(rumor);
 			string text = EvaluateText(rumor);
 
 			if (string.IsNullOrEmpty(dialog[speaker])

--- a/Nodes/Say.cs
+++ b/Nodes/Say.cs
@@ -114,10 +114,7 @@ namespace Exodrifter.Rumor.Nodes
 		/// <returns>The speaker.</returns>
 		public object EvaluateSpeaker(Engine.Rumor rumor)
 		{
-			if (speaker == null) {
-				return null;
-			}
-			return speaker.Evaluate(rumor.Scope).AsObject();
+			return EvaluateSpeaker(rumor.Scope);
 		}
 		
 		/// <summary>
@@ -128,9 +125,9 @@ namespace Exodrifter.Rumor.Nodes
 		public object EvaluateSpeaker(Scope scope)
 		{
 			if (speaker == null) {
-				return null;
+				return scope.DefaultSpeaker;
 			}
-			return speaker.Evaluate(scope).AsObject();
+			return speaker.Evaluate(scope).AsObject() ?? scope.DefaultSpeaker;
 		}
 
 		/// <summary>

--- a/Nodes/Say.cs
+++ b/Nodes/Say.cs
@@ -11,8 +11,13 @@ namespace Exodrifter.Rumor.Nodes
 	/// Sets the dialog in the rumor state.
 	/// </summary>
 	[Serializable]
-	public sealed class Say : Node
+	public class Say : Node
 	{
+		/// <summary>
+		/// The speaker to associate with the dialog.
+		/// </summary>
+		public object speaker;
+
 		/// <summary>
 		/// The text to replace the dialog with.
 		/// </summary>
@@ -26,6 +31,7 @@ namespace Exodrifter.Rumor.Nodes
 		/// </param>
 		public Say(string text)
 		{
+			this.speaker = null;
 			this.text = new LiteralExpression(text);
 		}
 
@@ -37,6 +43,37 @@ namespace Exodrifter.Rumor.Nodes
 		/// </param>
 		public Say(Expression text)
 		{
+			this.speaker = null;
+			this.text = text;
+		}
+
+		/// <summary>
+		/// Creates a new Say node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The text to replace the dialog with.
+		/// </param>
+		public Say(object speaker, string text)
+		{
+			this.speaker = speaker;
+			this.text = new LiteralExpression(text);
+		}
+
+		/// <summary>
+		/// Creates a new Say node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The expression to replace the dialog with.
+		/// </param>
+		public Say(object speaker, Expression text)
+		{
+			this.speaker = speaker;
 			this.text = text;
 		}
 
@@ -62,7 +99,9 @@ namespace Exodrifter.Rumor.Nodes
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
-			rumor.State.SetDialog(EvaluateText(rumor.Scope));
+			var speaker = this.speaker ?? RumorState.NARRATOR;
+			var text = EvaluateText(rumor);
+			rumor.State.SetDialog(speaker, text);
 			yield return new ForAdvance();
 		}
 
@@ -71,6 +110,7 @@ namespace Exodrifter.Rumor.Nodes
 		public Say(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
+			speaker = info.GetValue<object>("speaker");
 			text = info.GetValue<Expression>("text");
 		}
 
@@ -78,6 +118,7 @@ namespace Exodrifter.Rumor.Nodes
 			(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
+			info.AddValue<object>("speaker", speaker);
 			info.AddValue<Expression>("text", text);
 		}
 

--- a/Nodes/Say.cs
+++ b/Nodes/Say.cs
@@ -16,7 +16,7 @@ namespace Exodrifter.Rumor.Nodes
 		/// <summary>
 		/// The speaker to associate with the dialog.
 		/// </summary>
-		public object speaker;
+		public Expression speaker;
 
 		/// <summary>
 		/// The text to replace the dialog with.
@@ -56,7 +56,7 @@ namespace Exodrifter.Rumor.Nodes
 		/// <param name="text">
 		/// The text to replace the dialog with.
 		/// </param>
-		public Say(object speaker, string text)
+		public Say(Expression speaker, string text)
 		{
 			this.speaker = speaker;
 			this.text = new LiteralExpression(text);
@@ -71,10 +71,66 @@ namespace Exodrifter.Rumor.Nodes
 		/// <param name="text">
 		/// The expression to replace the dialog with.
 		/// </param>
-		public Say(object speaker, Expression text)
+		public Say(Expression speaker, Expression text)
 		{
 			this.speaker = speaker;
 			this.text = text;
+		}
+
+		/// <summary>
+		/// Creates a new Say node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The text to replace the dialog with.
+		/// </param>
+		public Say(object speaker, string text)
+		{
+			this.speaker = new LiteralExpression(speaker);
+			this.text = new LiteralExpression(text);
+		}
+
+		/// <summary>
+		/// Creates a new Say node.
+		/// </summary>
+		/// <param name="speaker">
+		/// The speaker to associate with the dialog.
+		/// </param>
+		/// <param name="text">
+		/// The expression to replace the dialog with.
+		/// </param>
+		public Say(object speaker, Expression text)
+		{
+			this.speaker = new LiteralExpression(speaker);
+			this.text = text;
+		}
+
+		/// <summary>
+		/// Evaluates the speaker of this node in the specified Rumor.
+		/// </summary>
+		/// <param name="rumor">The Rumor to evaluate against.</param>
+		/// <returns>The speaker.</returns>
+		public object EvaluateSpeaker(Engine.Rumor rumor)
+		{
+			if (speaker == null) {
+				return null;
+			}
+			return speaker.Evaluate(rumor.Scope).AsObject();
+		}
+		
+		/// <summary>
+		/// Evaluates the speaker of this node in the specified Scope.
+		/// </summary>
+		/// <param name="rumor">The Scope to evaluate against.</param>
+		/// <returns>The speaker.</returns>
+		public object EvaluateSpeaker(Scope scope)
+		{
+			if (speaker == null) {
+				return null;
+			}
+			return speaker.Evaluate(scope).AsObject();
 		}
 
 		/// <summary>
@@ -99,6 +155,7 @@ namespace Exodrifter.Rumor.Nodes
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
+			var speaker = EvaluateSpeaker(rumor);
 			var text = EvaluateText(rumor);
 			rumor.State.SetDialog(speaker, text);
 			yield return new ForAdvance();
@@ -109,7 +166,7 @@ namespace Exodrifter.Rumor.Nodes
 		public Say(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
-			speaker = info.GetValue<object>("speaker");
+			speaker = info.GetValue<Expression>("speaker");
 			text = info.GetValue<Expression>("text");
 		}
 
@@ -117,7 +174,7 @@ namespace Exodrifter.Rumor.Nodes
 			(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
-			info.AddValue<object>("speaker", speaker);
+			info.AddValue<Expression>("speaker", speaker);
 			info.AddValue<Expression>("text", text);
 		}
 

--- a/Nodes/Say.cs
+++ b/Nodes/Say.cs
@@ -99,7 +99,6 @@ namespace Exodrifter.Rumor.Nodes
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
-			var speaker = this.speaker ?? RumorState.NARRATOR;
 			var text = EvaluateText(rumor);
 			rumor.State.SetDialog(speaker, text);
 			yield return new ForAdvance();

--- a/Util/LazyDictionary.cs
+++ b/Util/LazyDictionary.cs
@@ -10,10 +10,35 @@ namespace Exodrifter.Rumor.Util
 	/// </summary>
 	[Serializable]
 	public class LazyDictionary<K, V> : ISerializable
+		where K : class where V : class
 	{
 		private Dictionary<K, V> dictionary;
 
 		private V nullValue;
+
+		public List<K> Keys
+		{
+			get
+			{
+				var list = new List<K>(dictionary.Keys);
+				if (nullValue != null) {
+					list.Add(null);
+				}
+				return list;
+			}
+		}
+
+		public List<V> Values
+		{
+			get
+			{
+				var list = new List<V>(dictionary.Values);
+				if (nullValue != null) {
+					list.Add(nullValue);
+				}
+				return list;
+			}
+		}
 
 		public V this[K key]
 		{

--- a/Util/LazyDictionary.cs
+++ b/Util/LazyDictionary.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Util
+{
+	/// <summary>
+	/// A wrapper around a dictionary that can return a result for any key even
+	/// if the key doesn't exist and can store a key value pair for a null key.
+	/// </summary>
+	[Serializable]
+	public class LazyDictionary<K, V> : ISerializable
+	{
+		private Dictionary<K, V> dictionary;
+
+		private V nullValue;
+
+		public V this[K key]
+		{
+			get
+			{
+				if (key == null) {
+					return nullValue;
+				}
+				if (dictionary.ContainsKey(key)) {
+					return dictionary[key];
+				}
+				return default(V);
+			}
+			set
+			{
+				if (key == null) {
+					nullValue = value;
+				}
+				else {
+					dictionary[key] = value;
+				}
+			}
+		}
+
+		public LazyDictionary()
+		{
+			dictionary = new Dictionary<K, V>();
+			nullValue = default(V);
+		}
+
+		public void Clear()
+		{
+			dictionary.Clear();
+			nullValue = default(V);
+		}
+
+		#region Serialization
+
+		public LazyDictionary(SerializationInfo info, StreamingContext context)
+		{
+			dictionary = info.GetValue<Dictionary<K, V>>("dictionary");
+			nullValue = info.GetValue<V>("nullValue");
+		}
+
+		public void GetObjectData
+			(SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue<Dictionary<K, V>>("dictionary", dictionary);
+			info.AddValue<V>("nullValue", nullValue);
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Added the ability to specify a speaker for any Say and Add node. To specify a speaker, the writer may provide a variable right before the expression that defines the text for that node. For example:

```
$ s = "Someone"
say s "Hey, who are you?"
```

The writer does not have to specify a speaker, so the following is still valid:

```
say "Hey, who are you?"
```

If the speaker is not specified, the default speaker (which is defined in `Scope.DefaultSpeaker`) will be used instead. A speaker can be any object. The writer CANNOT use an expression in place of the variable. That means the following won't compile:

```
say foo() "Hey, who are you?
```

```
say "Someone" "Hey, who are you?"
```

```
say "Some" + "one" "Hey, who are you?"
```

However, some of these scenarios seem useful, so I've added a comment noting that the parser should be able to parse these expressions properly as well.

The `RumorState` has also been changed to reflect the addition of speakers. Dialog is now a dictionary of speakers to text. This means you will need to access the dialog with the speaker key.

```
state.Dialog["Someone"]
```

If neither the speaker in the Say or Add nodes nor `Scope.DefaultSpeaker` are set, then this key will be null.