### PR TITLE
Various bugfixes

### DIFF
--- a/Editor/Tests/Engine/SerializationTest.cs
+++ b/Editor/Tests/Engine/SerializationTest.cs
@@ -271,7 +271,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			});
 			var b = Reserialize(a);
 
-			Assert.AreEqual(a.text, b.text);
+			Assert.AreEqual(a.EvaluateText(scope), b.EvaluateText(scope));
 			Assert.AreEqual(1, a.Children.Count);
 			Assert.AreEqual(a.Children.Count, b.Children.Count);
 			Assert.AreEqual(

--- a/Editor/Tests/Lang/CompilerTest.cs
+++ b/Editor/Tests/Lang/CompilerTest.cs
@@ -1,0 +1,55 @@
+﻿using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Lang;
+using Exodrifter.Rumor.Nodes;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Exodrifter.Rumor.Test.Lang
+{
+	internal class CompilerTest
+	{
+		[Test]
+		public void MultilineStringSpaces()
+		{
+			var str = "say \"This is a multiline\n      string.\"";
+			var nodes = new List<Node>(new RumorCompiler().Compile(str));
+			
+			var scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This is a multiline string.");
+		}
+		
+		[Test]
+		public void MultilineStringTabs()
+		{
+			var str = "say \"This is a multiline\n\tstring.\"";
+			var nodes = new List<Node>(new RumorCompiler().Compile(str));
+			
+			var scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This is a multiline string.");
+		}
+		
+		[Test]
+		public void MultilineStringMixed()
+		{
+			var str = "say \"This is a multiline\n  \t  \tstring.\"";
+			var nodes = new List<Node>(new RumorCompiler().Compile(str));
+			
+			var scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This is a multiline string.");
+		}
+
+		[Test]
+		public void MultilineStringPreserveSpaces()
+		{
+			var str = "say \"This  is  a  multiline\n\tstring.\"";
+			var nodes = new List<Node>(new RumorCompiler().Compile(str));
+			
+			var scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This  is  a  multiline string.");
+		}
+	}
+}

--- a/Editor/Tests/Lang/CompilerTest.cs
+++ b/Editor/Tests/Lang/CompilerTest.cs
@@ -13,29 +13,29 @@ namespace Exodrifter.Rumor.Test.Lang
 		{
 			var str = "say \"This is a multiline\n      string.\"";
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
-			
+
 			var scope = new Scope();
 			Assert.AreEqual(nodes.Count, 1);
 			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This is a multiline string.");
 		}
-		
+
 		[Test]
 		public void MultilineStringTabs()
 		{
 			var str = "say \"This is a multiline\n\tstring.\"";
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
-			
+
 			var scope = new Scope();
 			Assert.AreEqual(nodes.Count, 1);
 			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This is a multiline string.");
 		}
-		
+
 		[Test]
 		public void MultilineStringMixed()
 		{
 			var str = "say \"This is a multiline\n  \t  \tstring.\"";
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
-			
+
 			var scope = new Scope();
 			Assert.AreEqual(nodes.Count, 1);
 			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This is a multiline string.");
@@ -46,10 +46,61 @@ namespace Exodrifter.Rumor.Test.Lang
 		{
 			var str = "say \"This  is  a  multiline\n\tstring.\"";
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
-			
+
 			var scope = new Scope();
 			Assert.AreEqual(nodes.Count, 1);
 			Assert.AreEqual((nodes[0] as Say).EvaluateText(scope), "This  is  a  multiline string.");
+		}
+
+		[Test]
+		public void PauseAcceptsFloat()
+		{
+			var str = "pause 0";
+			var nodes = new List<Node>(new RumorCompiler().Compile(str));
+
+			var scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(scope).AsFloat(), 0f);
+
+			str = "pause .5";
+			nodes = new List<Node>(new RumorCompiler().Compile(str));
+
+			scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(scope).AsFloat(), 0.5f);
+
+			str = "pause 0.5";
+			nodes = new List<Node>(new RumorCompiler().Compile(str));
+
+			scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(scope).AsFloat(), 0.5f);
+
+			str = "pause 1";
+			nodes = new List<Node>(new RumorCompiler().Compile(str));
+
+			scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(scope).AsFloat(), 1f);
+		}
+
+		[Test]
+		public void PauseAcceptsExpression()
+		{
+			var str = "pause foo()";
+			var nodes = new List<Node>(new RumorCompiler().Compile(str));
+
+			var scope = new Scope();
+			scope.Bind("foo", () => { return 1f; });
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(scope).AsFloat(), 1f);
+
+			str = "pause 8.0 * 3.0";
+			nodes = new List<Node>(new RumorCompiler().Compile(str));
+
+			scope = new Scope();
+			Assert.AreEqual(nodes.Count, 1);
+			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(scope).AsFloat(), 24f);
 		}
 	}
 }

--- a/Editor/Tests/Nodes/ReturnTest.cs
+++ b/Editor/Tests/Nodes/ReturnTest.cs
@@ -1,0 +1,75 @@
+﻿using Exodrifter.Rumor.Nodes;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace Exodrifter.Rumor.Test.Nodes
+{
+	/// <summary>
+	/// Ensure Call nodes operate as expected.
+	/// </summary>
+	public class ReturnTest
+	{
+		/// <summary>
+		/// Ensure a single return call works as expected.
+		/// </summary>
+		[Test]
+		public void Return()
+		{
+			var rumor = new Rumor.Engine.Rumor(new List<Node>() {
+				new Return()
+			});
+
+			rumor.Run().MoveNext();
+			Assert.IsTrue(rumor.Finished);
+		}
+
+		/// <summary>
+		/// Ensure a return inside a jump works as expected.
+		/// </summary>
+		[Test]
+		public void ReturnInJump()
+		{
+			var rumor = new Rumor.Engine.Rumor(new List<Node>() {
+				new Jump("start"),
+				new Label("foo", new List<Node>() {
+					new Say("Something to prevent infinite loop"),
+					new Return()
+				}),
+				new Label("start", new List<Node>() {
+					new Jump("foo")
+				}),
+			});
+			
+			var yield = rumor.Run();
+			yield.MoveNext();
+			rumor.Advance();
+			yield.MoveNext();
+			Assert.IsFalse(rumor.Finished);
+		}
+
+		/// <summary>
+		/// Ensure a return inside a call works as expected.
+		/// </summary>
+		[Test]
+		public void ReturnInCall()
+		{
+			var rumor = new Rumor.Engine.Rumor(new List<Node>() {
+				new Jump("start"),
+				new Label("foo", new List<Node>() {
+					new Say("Something to prevent infinite loop"),
+					new Return()
+				}),
+				new Label("start", new List<Node>() {
+					new Call("foo")
+				}),
+			});
+
+			var yield = rumor.Run();
+			yield.MoveNext();
+			rumor.Advance();
+			yield.MoveNext();
+			Assert.IsTrue(rumor.Finished);
+		}
+	}
+}

--- a/Engine/Rumor.cs
+++ b/Engine/Rumor.cs
@@ -270,25 +270,20 @@ namespace Exodrifter.Rumor.Engine
 		/// </param>
 		internal void MoveToLabel(string label)
 		{
-			StackFrame toCopy = null;
+			StackFrame frameContainingLabel = null;
 			foreach (var frame in stack) {
 				if (frame.HasLabel(label)) {
-					toCopy = frame;
+					frameContainingLabel = frame;
 					break;
 				}
 			}
 
-			if (toCopy == null) {
+			if (frameContainingLabel == null) {
 				throw new InvalidOperationException(
 					"Label \"" + label + "\" cannot be found");
 			}
 
-			var newFrame = new StackFrame(toCopy);
-			newFrame.Reset();
-			newFrame.JumpToLabel(label);
-
-			newFrame.OnNextNode += OnNextNodeHandler;
-			stack.Push(newFrame);
+			EnterBlock(frameContainingLabel.GetChildrenOfLabel(label));
 		}
 
 		internal void OnNextNodeHandler(Node node)

--- a/Engine/StackFrame.cs
+++ b/Engine/StackFrame.cs
@@ -165,6 +165,25 @@ namespace Exodrifter.Rumor.Engine
 			return false;
 		}
 
+		/// <summary>
+		/// Returns the children of the specified label. Returns an empty list
+		/// if the label does not exist.
+		/// </summary>
+		/// <param name="name">
+		/// The name of the label to get the children of.
+		/// </param>
+		internal IEnumerable<Node> GetChildrenOfLabel(string name) {
+			for (int i = 0; i < nodes.Count; ++i) {
+				var label = nodes[i] as Label;
+
+				if (label != null && label.name == name) {
+					return label.Children;
+				}
+			}
+
+			return new List<Node>();
+		}
+
 		#region Serialization
 
 		public StackFrame(SerializationInfo info, StreamingContext context)

--- a/Expressions/Expression.cs
+++ b/Expressions/Expression.cs
@@ -19,6 +19,18 @@ namespace Exodrifter.Rumor.Expressions
 		/// <returns>The result of this expression when evaluated.</returns>
 		public abstract Value Evaluate(Scope scope);
 
+		/// <summary>
+		/// Evaluates this expression.
+		/// </summary>
+		/// <param name="rumor">
+		/// The Rumor containing the scope to evaluate against.
+		/// </param>
+		/// <returns>The result of this expression when evaluated.</returns>
+		public Value Evaluate(Engine.Rumor rumor)
+		{
+			return Evaluate(rumor.Scope);
+		}
+
 		#region Equality
 
 		public abstract override bool Equals(object obj);

--- a/Expressions/Expression.cs
+++ b/Expressions/Expression.cs
@@ -1,12 +1,17 @@
 ﻿using Exodrifter.Rumor.Engine;
+using System;
+using System.Runtime.Serialization;
 
 namespace Exodrifter.Rumor.Expressions
 {
 	/// <summary>
 	/// An expression is a set of operations that returns a result.
 	/// </summary>
-	public abstract class Expression
+	[Serializable]
+	public abstract class Expression : ISerializable
 	{
+		public Expression() { }
+
 		/// <summary>
 		/// Evaluates this expression.
 		/// </summary>
@@ -35,6 +40,17 @@ namespace Exodrifter.Rumor.Expressions
 		{
 			return !(a == b);
 		}
+
+		#endregion
+
+		#region Serialization
+
+		public Expression(SerializationInfo info, StreamingContext context)
+		{
+		}
+
+		public abstract void GetObjectData
+			(SerializationInfo info, StreamingContext context);
 
 		#endregion
 	}

--- a/Expressions/FunctionExpression.cs
+++ b/Expressions/FunctionExpression.cs
@@ -70,7 +70,7 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override string ToString()
 		{
-			return name;
+			return name + "()";
 		}
 
 		#region Equality

--- a/Expressions/FunctionExpression.cs
+++ b/Expressions/FunctionExpression.cs
@@ -10,7 +10,7 @@ namespace Exodrifter.Rumor.Expressions
 	/// Represents an expression that is a call to a function.
 	/// </summary>
 	[Serializable]
-	public class FunctionExpression : Expression, ISerializable
+	public class FunctionExpression : Expression
 	{
 		/// <summary>
 		/// The name of the function to call.
@@ -110,12 +110,13 @@ namespace Exodrifter.Rumor.Expressions
 
 		public FunctionExpression
 			(SerializationInfo info, StreamingContext context)
+			: base (info, context)
 		{
 			name = info.GetValue<string>("name");
 			@params = info.GetValue<List<Expression>>("params");
 		}
 
-		void ISerializable.GetObjectData
+		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue<string>("name", name);

--- a/Expressions/LiteralExpression.cs
+++ b/Expressions/LiteralExpression.cs
@@ -9,7 +9,7 @@ namespace Exodrifter.Rumor.Expressions
 	/// Represents an expression that is a literal.
 	/// </summary>
 	[Serializable]
-	public class LiteralExpression : Expression, ISerializable
+	public class LiteralExpression : Expression
 	{
 		/// <summary>
 		/// The value of this literal.
@@ -84,11 +84,12 @@ namespace Exodrifter.Rumor.Expressions
 
 		public LiteralExpression
 			(SerializationInfo info, StreamingContext context)
+			: base (info, context)
 		{
 			value = info.GetValue<Value>("value");
 		}
 
-		void ISerializable.GetObjectData
+		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue<Value>("value", value);

--- a/Expressions/LiteralExpression.cs
+++ b/Expressions/LiteralExpression.cs
@@ -51,7 +51,7 @@ namespace Exodrifter.Rumor.Expressions
 		{
 			if (value != null)
 				return value.ToString();
-			return "";
+			return "<null>";
 		}
 
 		#region Equality

--- a/Expressions/NoOpExpression.cs
+++ b/Expressions/NoOpExpression.cs
@@ -8,7 +8,7 @@ namespace Exodrifter.Rumor.Expressions
 	/// Represents an expression that does nothing.
 	/// </summary>
 	[Serializable]
-	public class NoOpExpression : Expression, ISerializable
+	public class NoOpExpression : Expression
 	{
 		public NoOpExpression()
 		{
@@ -52,7 +52,7 @@ namespace Exodrifter.Rumor.Expressions
 		{
 		}
 
-		void ISerializable.GetObjectData
+		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 		}

--- a/Expressions/NotExpression.cs
+++ b/Expressions/NotExpression.cs
@@ -18,6 +18,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Evaluate(Scope scope)
 		{
 			var r = right.Evaluate(scope);
+			if (r == null) {
+				return new BoolValue(true);
+			}
 			return r.Not();
 		}
 

--- a/Expressions/OpExpression.cs
+++ b/Expressions/OpExpression.cs
@@ -3,7 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Exodrifter.Rumor.Expressions
 {
-	public abstract class OpExpression : Expression, ISerializable
+	public abstract class OpExpression : Expression
 	{
 		/// <summary>
 		/// The left-hand argument for this expression.
@@ -62,7 +62,7 @@ namespace Exodrifter.Rumor.Expressions
 			right = info.GetValue<Expression>("right");
 		}
 
-		void ISerializable.GetObjectData
+		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue<Expression>("left", left);

--- a/Expressions/SetExpression.cs
+++ b/Expressions/SetExpression.cs
@@ -31,7 +31,7 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override string ToString()
 		{
-			return left + "+" + right;
+			return left + "=" + right;
 		}
 
 		#region Serialization

--- a/Expressions/Value/BoolValue.cs
+++ b/Expressions/Value/BoolValue.cs
@@ -18,6 +18,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Add(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(AsBool());
+			}
 			if (value.IsString()) {
 				var @bool = AsBool().ToString().ToLower();
 				return new StringValue(@bool + value.AsString());
@@ -42,6 +45,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolAnd(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(false);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsBool() && value.AsInt() != 0);
 			}
@@ -59,6 +65,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolOr(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(AsBool());
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsBool() || value.AsInt() != 0);
 			}

--- a/Expressions/Value/FloatValue.cs
+++ b/Expressions/Value/FloatValue.cs
@@ -18,6 +18,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Add(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() + value.AsInt());
 			}
@@ -32,6 +35,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Subtract(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() - value.AsInt());
 			}
@@ -43,6 +49,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Multiply(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() * value.AsInt());
 			}
@@ -54,6 +63,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Divide(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() / value.AsInt());
 			}
@@ -65,6 +77,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolAnd(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(false);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsFloat() != 0 && value.AsInt() != 0);
 			}
@@ -82,6 +97,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolOr(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(AsFloat() != 0);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsFloat() != 0 || value.AsInt() != 0);
 			}

--- a/Expressions/Value/IntValue.cs
+++ b/Expressions/Value/IntValue.cs
@@ -18,6 +18,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Add(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() + value.AsInt());
 			}
@@ -32,6 +35,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Subtract(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() - value.AsInt());
 			}
@@ -43,6 +49,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Multiply(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() * value.AsInt());
 			}
@@ -54,6 +63,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Divide(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() / value.AsInt());
 			}
@@ -65,6 +77,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolAnd(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(false);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsInt() != 0 && value.AsInt() != 0);
 			}
@@ -82,6 +97,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolOr(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(AsInt() != 0);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsInt() != 0 || value.AsInt() != 0);
 			}

--- a/Expressions/Value/ObjectValue.cs
+++ b/Expressions/Value/ObjectValue.cs
@@ -18,6 +18,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Add(Value value)
 		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
 			if (value.IsString()) {
 				return new StringValue(AsObject() + value.AsString());
 			}

--- a/Expressions/Value/StringValue.cs
+++ b/Expressions/Value/StringValue.cs
@@ -18,6 +18,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Add(Value value)
 		{
+			if (value == null) {
+				return new StringValue(AsString());
+			}
 			if (value.IsBool()) {
 				var @bool = value.AsBool().ToString().ToLower();
 				return new StringValue(AsString() + @bool);
@@ -54,6 +57,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolAnd(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(false);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsString() != "" && value.AsInt() != 0);
 			}
@@ -71,6 +77,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value BoolOr(Value value)
 		{
+			if (value == null) {
+				return new BoolValue(AsString() != "");
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsString() != "" || value.AsInt() != 0);
 			}

--- a/Expressions/Value/Value.cs
+++ b/Expressions/Value/Value.cs
@@ -20,6 +20,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override string ToString()
 		{
+			if (value == null) {
+				return "<null>";
+			}
 			return value.ToString();
 		}
 
@@ -86,6 +89,8 @@ namespace Exodrifter.Rumor.Expressions
 		{
 			if (value is int)
 				return (int)value;
+			if (value is float)
+				return (int)(float)value;
 			return num;
 		}
 
@@ -100,6 +105,8 @@ namespace Exodrifter.Rumor.Expressions
 		{
 			if (value is float)
 				return (float)value;
+			if (value is int)
+				return (float)(int)value;
 			return num;
 		}
 

--- a/Expressions/VariableExpression.cs
+++ b/Expressions/VariableExpression.cs
@@ -9,7 +9,7 @@ namespace Exodrifter.Rumor.Expressions
 	/// Represents an expression that is a variable.
 	/// </summary>
 	[Serializable]
-	public class VariableExpression : Expression, ISerializable
+	public class VariableExpression : Expression
 	{
 		/// <summary>
 		/// The name of the variable
@@ -62,11 +62,12 @@ namespace Exodrifter.Rumor.Expressions
 
 		public VariableExpression
 			(SerializationInfo info, StreamingContext context)
+			: base (info, context)
 		{
 			name = info.GetValue<string>("name");
 		}
 
-		void ISerializable.GetObjectData
+		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue<string>("name", name);

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -2,6 +2,7 @@
 using Exodrifter.Rumor.Expressions;
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Exodrifter.Rumor.Lang
 {
@@ -744,6 +745,10 @@ namespace Exodrifter.Rumor.Lang
 					break;
 				}
 			}
+
+			// Replace multiline whitespace with a single space
+			var re = new Regex(@"\n\s+");
+			quote = re.Replace(quote, " ");
 
 			return foundEndQuote ? quote : null;
 		}

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -65,10 +65,12 @@ namespace Exodrifter.Rumor.Lang
 			handlers = new Dictionary<string, NodeParser>();
 			handlers["$"] = CompileStatement;
 			handlers["add"] = CompileAdd;
+			handlers["call"] = CompileCall;
 			handlers["choice"] = CompileChoice;
 			handlers["jump"] = CompileJump;
 			handlers["label"] = CompileLabel;
 			handlers["pause"] = CompilePause;
+			handlers["return"] = CompileReturn;
 			handlers["say"] = CompileSay;
 
 			conditions = new Dictionary<string, ConditionalParser>();
@@ -388,6 +390,14 @@ namespace Exodrifter.Rumor.Lang
 			}
 		}
 
+		private Node CompileCall(LogicalLine line, ref int pos, List<Node> children)
+		{
+			ExpectNoChildren(line, children);
+
+			var name = Expect(line, pos++);
+			return new Call(name);
+		}
+
 		private Node CompileChoice(LogicalLine line, ref int pos, List<Node> children)
 		{
 			int end = Seek(line, pos, ":");
@@ -427,6 +437,12 @@ namespace Exodrifter.Rumor.Lang
 			var tokens = Slice(line.tokens, pos);
 			var expression = CompileExpression(tokens);
 			return new Pause(expression);
+		}
+
+		private Node CompileReturn(LogicalLine line, ref int pos, List<Node> children)
+		{
+			ExpectNoChildren(line, children);
+			return new Return();
 		}
 
 		private Node CompileSay(LogicalLine line, ref int pos, List<Node> children)

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -420,8 +420,9 @@ namespace Exodrifter.Rumor.Lang
 		{
 			ExpectNoChildren(line, children);
 
-			float seconds = Float(line, ref pos);
-			return new Pause(seconds);
+			var tokens = Slice(line.tokens, pos);
+			var expression = CompileExpression(tokens);
+			return new Pause(expression);
 		}
 
 		private Node CompileSay(LogicalLine line, ref int pos, List<Node> children)

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -390,9 +390,13 @@ namespace Exodrifter.Rumor.Lang
 
 		private Node CompileChoice(LogicalLine line, ref int pos, List<Node> children)
 		{
-			string text = Quote(line, ref pos);
+			int end = Seek(line, pos, ":");
 
-			SkipWhitespace(line, ref pos);
+			var tokens = Slice(line.tokens, pos, end);
+			var text = CompileExpression(tokens);
+
+			pos = end;
+
 			Expect(line, pos++, ":");
 
 			return new Choice(text, children);

--- a/Nodes/Choice.cs
+++ b/Nodes/Choice.cs
@@ -1,4 +1,5 @@
 ﻿using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
 using Exodrifter.Rumor.Util;
 using System;
 using System.Collections.Generic;
@@ -15,7 +16,7 @@ namespace Exodrifter.Rumor.Nodes
 		/// <summary>
 		/// The text to display for this choice.
 		/// </summary>
-		public readonly string text;
+		private readonly Expression text;
 
 		/// <summary>
 		/// Creates a new choice
@@ -29,12 +30,37 @@ namespace Exodrifter.Rumor.Nodes
 		public Choice(string text, IEnumerable<Node> children)
 			: base(children)
 		{
+			this.text = new LiteralExpression(text);
+		}
+
+		/// <summary>
+		/// Creates a new choice
+		/// </summary>
+		/// <param name="text">
+		/// The text to display for this choice.
+		/// </param>
+		/// <param name="children">
+		/// The children for this choice.
+		/// </param>
+		public Choice(Expression text, IEnumerable<Node> children)
+			: base(children)
+		{
 			this.text = text;
+		}
+
+		public string EvaluateText(Scope scope)
+		{
+			return text.Evaluate(scope).AsString();
+		}
+
+		public string EvaluateText(Engine.Rumor rumor)
+		{
+			return text.Evaluate(rumor).AsString();
 		}
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
-			rumor.State.AddChoice(text, this.Children);
+			rumor.State.AddChoice(EvaluateText(rumor), this.Children);
 
 			// Wait for a choice to be made if we're done adding choices
 			if (!(rumor.Next is Choice)) {
@@ -47,14 +73,14 @@ namespace Exodrifter.Rumor.Nodes
 		public Choice(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
-			text = info.GetValue<string>("text");
+			text = info.GetValue<Expression>("text");
 		}
 
 		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
-			info.AddValue<string>("text", text);
+			info.AddValue<Expression>("text", text);
 		}
 
 		#endregion

--- a/Nodes/Pause.cs
+++ b/Nodes/Pause.cs
@@ -1,4 +1,5 @@
 ﻿using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
 using Exodrifter.Rumor.Util;
 using System;
 using System.Collections.Generic;
@@ -15,7 +16,7 @@ namespace Exodrifter.Rumor.Nodes
 		/// <summary>
 		/// The number of seconds to pause for.
 		/// </summary>
-		public readonly float seconds;
+		public readonly Expression seconds;
 
 		/// <summary>
 		/// Creates a new pause node.
@@ -25,12 +26,23 @@ namespace Exodrifter.Rumor.Nodes
 		/// </param>
 		public Pause(float seconds)
 		{
-			this.seconds = seconds;
+			this.seconds = new LiteralExpression(seconds);
+		}
+
+		/// <summary>
+		/// Creates a new pause node.
+		/// </summary>
+		/// <param name="seconds">
+		/// The number of seconds to pause for.
+		/// </param>
+		public Pause(Expression expression)
+		{
+			this.seconds = expression;
 		}
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
-			yield return new ForSeconds(seconds);
+			yield return new ForSeconds(seconds.Evaluate(rumor).AsFloat());
 		}
 
 		#region Serialization
@@ -38,14 +50,14 @@ namespace Exodrifter.Rumor.Nodes
 		public Pause(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
-			seconds = info.GetValue<float>("seconds");
+			seconds = info.GetValue<Expression>("seconds");
 		}
 
 		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
-			info.AddValue<float>("seconds", seconds);
+			info.AddValue<Expression>("seconds", seconds);
 		}
 
 		#endregion


### PR DESCRIPTION
Fixed several bugs:
* Fix a serialization error with Expressions
* Value operator methods are more null resilient
* Some expressions had incorrect `ToString()` methods
* Added the missing `return` and `call` nodes
* Fix improper call behaviour
* Fix multiline strings containing extra whitespace
* Several classes (`pause` and `choice`) have been changed to use expressions instead of their original values
