### PR TITLE
Auto advance and cancels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+###
+- Added an `AutoAdvance` property to Rumor that causes it to automatically
+  advance if possible
+
 
 ## [0.1.1] - 2016-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-###
+### Added
 - Added an `AutoAdvance` property to Rumor that causes it to automatically
   advance if possible
+- Added functions to Rumor for cancelling or finishing
+- Added properties to Rumor that track the number of times it has been
+  cancelled and finished
 
 
 ## [0.1.1] - 2016-10-31

--- a/Engine/Rumor.cs
+++ b/Engine/Rumor.cs
@@ -84,6 +84,11 @@ namespace Exodrifter.Rumor.Engine
 		public bool Running { get { return Started && !Finished; } }
 
 		/// <summary>
+		/// True if the script should automatically advance if it can.
+		/// </summary>
+		public bool AutoAdvance { get; set; }
+
+		/// <summary>
 		/// An event that is called right before a new node is executed.
 		/// </summary>
 		public event Action<Node> OnNextNode;
@@ -202,7 +207,13 @@ namespace Exodrifter.Rumor.Engine
 				// Execute the next statement
 				yield = stack.Peek().Run(this);
 				while (yield.MoveNext()) {
+					if (AutoAdvance) {
+						Advance();
+					}
 					while (yield.Current != null && !yield.Current.Finished) {
+						if (AutoAdvance) {
+							Advance();
+						}
 						yield return null;
 					}
 				}

--- a/Engine/Rumor.cs
+++ b/Engine/Rumor.cs
@@ -103,6 +103,21 @@ namespace Exodrifter.Rumor.Engine
 		/// </summary>
 		public event Action OnFinish;
 
+		/// <summary>
+		/// An event that is called when the Rumor is execution is cancelled.
+		/// </summary>
+		public event Action OnCancel;
+
+		/// <summary>
+		/// The number of times this rumor has been finished.
+		/// </summary>
+		public int FinishCount { get; set; }
+
+		/// <summary>
+		/// The number of times this rumor has been cancelled.
+		/// </summary>
+		public int CancelCount { get; set; }
+
 		private Rumor()
 		{
 			this.stack = new Stack<StackFrame>();
@@ -196,7 +211,7 @@ namespace Exodrifter.Rumor.Engine
 				OnStart();
 			}
 
-			while (stack.Count > 0) {
+			while (stack.Count > 0 && !Finished) {
 
 				// Check if the stack frame is exhausted
 				if (stack.Peek().Finished) {
@@ -206,11 +221,11 @@ namespace Exodrifter.Rumor.Engine
 
 				// Execute the next statement
 				yield = stack.Peek().Run(this);
-				while (yield.MoveNext()) {
+				while (yield.MoveNext() && !Finished) {
 					if (AutoAdvance) {
 						Advance();
 					}
-					while (yield.Current != null && !yield.Current.Finished) {
+					while (yield.Current != null && !yield.Current.Finished && !Finished) {
 						if (AutoAdvance) {
 							Advance();
 						}
@@ -219,13 +234,7 @@ namespace Exodrifter.Rumor.Engine
 				}
 			}
 
-			// Reset the state when we are finished
-			State.Reset();
-			Finished = true;
-
-			if (OnFinish != null) {
-				OnFinish();
-			}
+			Finish();
 		}
 
 		private void Init()
@@ -269,6 +278,44 @@ namespace Exodrifter.Rumor.Engine
 
 			if (null != yield.Current) {
 				yield.Current.OnAdvance();
+			}
+		}
+
+		/// <summary>
+		/// Forces the script to immediately finish.
+		/// </summary>
+		public void Finish()
+		{
+			if (!Running) {
+				return;
+			}
+
+			State.Reset();
+			Finished = true;
+
+			FinishCount++;
+
+			if (OnFinish != null) {
+				OnFinish();
+			}
+		}
+
+		/// <summary>
+		/// Cancels the rumor script, as if the user cancelled the dialog.
+		/// </summary>
+		public void Cancel()
+		{
+			if (!Running) {
+				return;
+			}
+
+			State.Reset();
+			Finished = true;
+
+			CancelCount++;
+
+			if (OnCancel != null) {
+				OnCancel();
 			}
 		}
 
@@ -387,6 +434,9 @@ namespace Exodrifter.Rumor.Engine
 			scope = info.GetValue<Scope>("scope");
 
 			State = info.GetValue<RumorState>("state");
+
+			FinishCount = info.GetValue<int>("finishCount");
+			CancelCount = info.GetValue<int>("cancelCount");
 		}
 
 		void ISerializable.GetObjectData
@@ -397,6 +447,9 @@ namespace Exodrifter.Rumor.Engine
 			info.AddValue<Scope>("scope", scope);
 
 			info.AddValue<RumorState>("state", State);
+
+			info.AddValue<int>("finishCount", FinishCount);
+			info.AddValue<int>("cancelCount", CancelCount);
 		}
 
 		#endregion


### PR DESCRIPTION
- Added an `AutoAdvance` property to Rumor that causes it to automatically
  advance if possible
- Added functions to Rumor for cancelling or finishing
- Added properties to Rumor that track the number of times it has been
  cancelled and finished