### PR TITLE
Choose nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   advance if possible
 - Added `Cancel` and `Finish` functions to Rumor
 - Added `CancelCount` and `FinishCount` properties to Rumor
+- Added a `Choose` node
+
+### Changed
+- `Choice` nodes no longer automatically wait for a choice at the end of a
+  chain of choices. Instead, use the `Choose` node to wait for a choice
 
 
 ## [0.1.1] - 2016-10-31

--- a/Editor/Tests/Engine/YieldTest.cs
+++ b/Editor/Tests/Engine/YieldTest.cs
@@ -17,7 +17,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			var yield = new ForAdvance();
 			Assert.False(yield.Finished);
 
-			yield.OnUpdate(0);
+			yield.OnUpdate(null, 0);
 			Assert.False(yield.Finished);
 
 			yield.OnAdvance();
@@ -37,7 +37,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			var yield = new ForChoice(1, 0, 0);
 			Assert.False(yield.Finished);
 
-			yield.OnUpdate(0);
+			yield.OnUpdate(null, 0);
 			Assert.False(yield.Finished);
 
 			yield.OnAdvance();
@@ -49,7 +49,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			yield.OnChoice();
 			Assert.True(yield.Finished);
 
-			yield.OnUpdate(0);
+			yield.OnUpdate(null, 0);
 			Assert.True(yield.Finished);
 
 			yield.OnAdvance();
@@ -59,7 +59,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			yield = new ForChoice(2, 0, 0);
 			Assert.False(yield.Finished);
 
-			yield.OnUpdate(0);
+			yield.OnUpdate(null, 0);
 			Assert.False(yield.Finished);
 
 			yield.OnAdvance();
@@ -74,7 +74,7 @@ namespace Exodrifter.Rumor.Test.Engine
 			yield.OnChoice();
 			Assert.True(yield.Finished);
 
-			yield.OnUpdate(0);
+			yield.OnUpdate(null, 0);
 			Assert.True(yield.Finished);
 
 			yield.OnAdvance();
@@ -84,19 +84,16 @@ namespace Exodrifter.Rumor.Test.Engine
 			yield = new ForChoice(2, 2, 0);
 			Assert.False(yield.Finished);
 
-			yield.OnUpdate(1);
+			yield.OnUpdate(null, 1);
 			Assert.False(yield.Finished);
 
 			yield.OnAdvance();
 			Assert.False(yield.Finished);
 
-			yield.OnChoice();
-			Assert.False(yield.Finished);
-
-			yield.OnUpdate(1);
+			yield.OnUpdate(null, 1);
 			Assert.True(yield.Finished);
 
-			yield.OnUpdate(1);
+			yield.OnUpdate(null, 1);
 			Assert.True(yield.Finished);
 
 			yield.OnAdvance();
@@ -121,13 +118,13 @@ namespace Exodrifter.Rumor.Test.Engine
 			yield.OnChoice();
 			Assert.False(yield.Finished);
 
-			yield.OnUpdate(0);
+			yield.OnUpdate(null, 0);
 			Assert.False(yield.Finished);
 
-			yield.OnUpdate(1);
+			yield.OnUpdate(null, 1);
 			Assert.True(yield.Finished);
 
-			yield.OnUpdate(1);
+			yield.OnUpdate(null, 1);
 			Assert.True(yield.Finished);
 		}
 	}

--- a/Editor/Tests/Engine/YieldTest.cs
+++ b/Editor/Tests/Engine/YieldTest.cs
@@ -33,7 +33,8 @@ namespace Exodrifter.Rumor.Test.Engine
 		[Test]
 		public void YieldChoice()
 		{
-			var yield = new ForChoice();
+			// Choose 1
+			var yield = new ForChoice(1, 0, 0);
 			Assert.False(yield.Finished);
 
 			yield.OnUpdate(0);
@@ -43,6 +44,62 @@ namespace Exodrifter.Rumor.Test.Engine
 			Assert.False(yield.Finished);
 
 			yield.OnChoice();
+			Assert.True(yield.Finished);
+
+			yield.OnChoice();
+			Assert.True(yield.Finished);
+
+			yield.OnUpdate(0);
+			Assert.True(yield.Finished);
+
+			yield.OnAdvance();
+			Assert.True(yield.Finished);
+
+			// Multiple
+			yield = new ForChoice(2, 0, 0);
+			Assert.False(yield.Finished);
+
+			yield.OnUpdate(0);
+			Assert.False(yield.Finished);
+
+			yield.OnAdvance();
+			Assert.False(yield.Finished);
+
+			yield.OnChoice();
+			Assert.False(yield.Finished);
+
+			yield.OnChoice();
+			Assert.True(yield.Finished);
+
+			yield.OnChoice();
+			Assert.True(yield.Finished);
+
+			yield.OnUpdate(0);
+			Assert.True(yield.Finished);
+
+			yield.OnAdvance();
+			Assert.True(yield.Finished);
+
+			// Timed
+			yield = new ForChoice(2, 2, 0);
+			Assert.False(yield.Finished);
+
+			yield.OnUpdate(1);
+			Assert.False(yield.Finished);
+
+			yield.OnAdvance();
+			Assert.False(yield.Finished);
+
+			yield.OnChoice();
+			Assert.False(yield.Finished);
+
+			yield.OnUpdate(1);
+			Assert.True(yield.Finished);
+
+			yield.OnUpdate(1);
+			Assert.True(yield.Finished);
+
+			yield.OnAdvance();
 			Assert.True(yield.Finished);
 
 			yield.OnChoice();

--- a/Engine/Rumor.cs
+++ b/Engine/Rumor.cs
@@ -64,6 +64,20 @@ namespace Exodrifter.Rumor.Engine
 		}
 
 		/// <summary>
+		/// Returns true if we are currently on a choose node.
+		/// </summary>
+		public bool Choosing
+		{
+			get
+			{
+				if (Current == null) {
+					return false;
+				}
+				return Current.GetType() == typeof(Choose);
+			}
+		}
+
+		/// <summary>
 		/// The state of the script.
 		/// </summary>
 		public RumorState State { get; private set; }

--- a/Engine/RumorState.cs
+++ b/Engine/RumorState.cs
@@ -86,6 +86,16 @@ namespace Exodrifter.Rumor.Engine
 		}
 
 		/// <summary>
+		/// Removes the choice at the specified index.
+		/// </summary>
+		/// <param name="index">The index of the choice to remove.</param>
+		public void RemoveChoice(int index)
+		{
+			Choices.RemoveAt(index);
+			Consequences.RemoveAt(index);
+		}
+
+		/// <summary>
 		/// Removes all current choices.
 		/// </summary>
 		public void ClearChoices()

--- a/Engine/Yields.cs
+++ b/Engine/Yields.cs
@@ -14,10 +14,13 @@
 		/// <summary>
 		/// Called when an update event occurs.
 		/// </summary>
+		/// <param name="rumor">
+		/// The rumor using this yield.
+		/// </param>
 		/// <param name="delta">
 		/// The amount of time in seconds since the last time this was called.
 		/// </param>
-		public virtual void OnUpdate(float delta) { }
+		public virtual void OnUpdate(Rumor rumor, float delta) { }
 
 		/// <summary>
 		/// Called when an advance event occurs.
@@ -60,7 +63,7 @@
 		/// <summary>
 		/// The number of seconds left to make a choice.
 		/// </summary>
-		public float SecondsLeft { get { return seconds; } }
+		public float SecondsLeft { get { return secondsLeft; } }
 		public int Default { get { return @default; } }
 
 		public ForChoice(int number, float seconds, int @default)
@@ -72,8 +75,13 @@
 			this.doUpdate = seconds > 0;
 		}
 
-		public override void OnUpdate(float delta)
+		public override void OnUpdate(Rumor rumor, float delta)
 		{
+			// Return early if there are no choices left
+			if (rumor != null && rumor.State.Choices.Count == 0) {
+				Finished = true;
+			}
+
 			if (!doUpdate || Finished) {
 				return;
 			}
@@ -81,7 +89,13 @@
 			if (secondsLeft > 0) {
 				secondsLeft -= delta;
 			}
-			Finished = secondsLeft <= 0;
+
+			if (secondsLeft <= 0) {
+				if (rumor != null) {
+					rumor.Choose(@default);
+				}
+				Finished = true;
+			}
 		}
 
 		public override void OnChoice()
@@ -110,7 +124,7 @@
 			this.seconds = seconds;
 		}
 
-		public override void OnUpdate(float delta)
+		public override void OnUpdate(Rumor rumor, float delta)
 		{
 			if (seconds > 0) {
 				seconds -= delta;

--- a/Engine/Yields.cs
+++ b/Engine/Yields.cs
@@ -42,13 +42,59 @@
 	}
 
 	/// <summary>
-	/// Yields until a choice event occurs.
+	/// Yields until the correct number of choice event occurs.
 	/// </summary>
 	public class ForChoice : RumorYield
 	{
+		private int number;
+		private float seconds;
+		private float secondsLeft;
+		private int @default;
+		private bool doUpdate;
+
+		/// <summary>
+		/// The number of choices left to make.
+		/// </summary>
+		public int NumberLeft { get { return number; } }
+
+		/// <summary>
+		/// The number of seconds left to make a choice.
+		/// </summary>
+		public float SecondsLeft { get { return seconds; } }
+		public int Default { get { return @default; } }
+
+		public ForChoice(int number, float seconds, int @default)
+		{
+			this.number = number;
+			this.seconds = seconds;
+			this.secondsLeft = seconds;
+			this.@default = @default;
+			this.doUpdate = seconds > 0;
+		}
+
+		public override void OnUpdate(float delta)
+		{
+			if (!doUpdate || Finished) {
+				return;
+			}
+
+			if (secondsLeft > 0) {
+				secondsLeft -= delta;
+			}
+			Finished = secondsLeft <= 0;
+		}
+
 		public override void OnChoice()
 		{
-			Finished = true;
+			if (Finished) {
+				return;
+			}
+
+			number = number - 1;
+			Finished = number <= 0;
+
+			// Reset the timer
+			secondsLeft = seconds;
 		}
 	}
 

--- a/Examples/RumorScriptExample.cs
+++ b/Examples/RumorScriptExample.cs
@@ -28,6 +28,7 @@ label start:
 		say ""Darn...""
 		pause 0.5
 		add ""Maybe next time.""
+	choose
 
 say ""Well, thanks for stopping by!""
 say ""See you next time!""
@@ -44,7 +45,7 @@ say ""See you next time!""
 				return;
 			}
 
-			if (rumor.State.Choices.Count > 0) {
+			if (rumor.Choosing) {
 				int num = 1;
 				text.text = "";
 

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -419,7 +419,7 @@ namespace Exodrifter.Rumor.Lang
 
 			SkipWhitespace(line, ref pos);
 			Expression number = new LiteralExpression(1);
-			if (line.tokens.Count != pos) {
+			if (line.tokens.Count != pos && line.tokens[pos].text != "in") {
 				int end = Seek(line, pos, "in", false);
 				var tokens = Slice(line.tokens, pos, end);
 				number = CompileExpression(tokens);

--- a/Nodes/Choice.cs
+++ b/Nodes/Choice.cs
@@ -61,11 +61,7 @@ namespace Exodrifter.Rumor.Nodes
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
 			rumor.State.AddChoice(EvaluateText(rumor), this.Children);
-
-			// Wait for a choice to be made if we're done adding choices
-			if (!(rumor.Next is Choice)) {
-				yield return new ForChoice();
-			}
+			yield return null;
 		}
 
 		#region Serialization

--- a/Nodes/Choose.cs
+++ b/Nodes/Choose.cs
@@ -152,6 +152,8 @@ namespace Exodrifter.Rumor.Nodes
 			int @default = EvaluateDefault(rumor);
 
 			yield return new ForChoice(number, time, @default);
+
+			rumor.State.ClearChoices();
 		}
 
 		#region Serialization

--- a/Nodes/Choose.cs
+++ b/Nodes/Choose.cs
@@ -1,0 +1,178 @@
+﻿using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
+using Exodrifter.Rumor.Util;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Nodes
+{
+	/// <summary>
+	/// Adds a choose to the rumor state.
+	/// </summary>
+	[Serializable]
+	public class Choose : Node
+	{
+		/// <summary>
+		/// The number of items to choose.
+		/// </summary>
+		private readonly Expression number;
+
+		/// <summary>
+		/// The amount of time in seconds to make each choice. If the amount of
+		/// time is less than or equal to zero, then the user may take as long
+		/// as they wish.
+		/// </summary>
+		private readonly Expression seconds;
+
+		/// <summary>
+		/// The index of the choice to pick when time runs out.
+		/// </summary>
+		private readonly Expression @default;
+
+		/// <summary>
+		/// Creates a new choose.
+		/// </summary>
+		/// <param name="number">
+		/// The number of choices to pick.
+		/// </param>
+		/// <param name="children">
+		/// The children for this choose.
+		/// </param>
+		public Choose(IEnumerable<Node> children)
+			: base(children)
+		{
+			this.number = new LiteralExpression(1);
+			this.seconds = new LiteralExpression(0);
+			this.@default = new LiteralExpression(0);
+		}
+
+		/// <summary>
+		/// Creates a new choose.
+		/// </summary>
+		/// <param name="number">
+		/// The number of choices to pick.
+		/// </param>
+		/// <param name="children">
+		/// The children for this choose.
+		/// </param>
+		public Choose(int number, IEnumerable<Node> children)
+			: base(children)
+		{
+			this.number = new LiteralExpression(number);
+			this.seconds = new LiteralExpression(0);
+			this.@default = new LiteralExpression(0);
+		}
+
+		/// <summary>
+		/// Creates a new choose.
+		/// </summary>
+		/// <param name="number">
+		/// The number of choices to pick.
+		/// </param>
+		/// <param name="seconds">
+		/// The amount of time in seconds to make each choice.
+		/// </param>
+		/// <param name="children">
+		/// The children for this choose.
+		/// </param>
+		public Choose(int number, float seconds, IEnumerable<Node> children)
+			: base(children)
+		{
+			this.number = new LiteralExpression(number);
+			this.seconds = new LiteralExpression(seconds);
+			this.@default = new LiteralExpression(0);
+		}
+
+		/// <summary>
+		/// Creates a new choose.
+		/// </summary>
+		/// <param name="number">
+		/// The number of choices to pick.
+		/// </param>
+		/// <param name="seconds">
+		/// The amount of time in seconds to make each choice.
+		/// </param>
+		/// <param name="@default">
+		/// The index of the choice to pick when time runs out.
+		/// </param>
+		/// <param name="children">
+		/// The children for this choose.
+		/// </param>
+		public Choose(int number, float seconds, int @default, IEnumerable<Node> children)
+			: base(children)
+		{
+			this.number = new LiteralExpression(number);
+			this.seconds = new LiteralExpression(seconds);
+			this.@default = new LiteralExpression(@default);
+		}
+
+		/// <summary>
+		/// Creates a new choose.
+		/// </summary>
+		/// <param name="number">
+		/// The number of choices to pick.
+		/// </param>
+		/// <param name="number">
+		/// The amount of time in seconds to make each choice.
+		/// </param>
+		/// <param name="@default">
+		/// The index of the choice to pick when time runs out.
+		/// </param>
+		/// <param name="children">
+		/// The children for this choose.
+		/// </param>
+		public Choose(Expression number, Expression seconds, Expression @default, IEnumerable<Node> children)
+			: base(children)
+		{
+			this.number = number;
+			this.seconds = seconds;
+			this.@default = @default;
+		}
+
+		public int EvaluateNumber(Engine.Rumor rumor)
+		{
+			return number.Evaluate(rumor).AsInt(1);
+		}
+
+		public float EvaluateTime(Engine.Rumor rumor)
+		{
+			return seconds.Evaluate(rumor).AsFloat(0);
+		}
+
+		public int EvaluateDefault(Engine.Rumor rumor)
+		{
+			return @default.Evaluate(rumor).AsInt(0);
+		}
+
+		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
+		{
+			int number = EvaluateNumber(rumor);
+			float time = EvaluateTime(rumor);
+			int @default = EvaluateDefault(rumor);
+
+			yield return new ForChoice(number, time, @default);
+		}
+
+		#region Serialization
+
+		public Choose(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			number = info.GetValue<Expression>("number");
+			seconds = info.GetValue<Expression>("time");
+			@default = info.GetValue<Expression>("default");
+		}
+
+		public override void GetObjectData
+			(SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData(info, context);
+			info.AddValue<Expression>("number", number);
+			info.AddValue<Expression>("time", seconds);
+			info.AddValue<Expression>("default", @default);
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Add Choose nodes, which change the behaviour for Choice nodes.

Now, instead of waiting automatically for a choice at the end of consecutive choices, you need to explicitly wait for a choice by using the Choose command. Choose will allow you to specify the number of unique choices to pick, the amount of time to wait before picking a default choice, and what the default choice should be.

Here are several examples:
```
# Choose one choice
choose
```
```
# Choose two choices
choose 2
```
```
# Choose a choice in 10 seconds
choose in 10 seconds
```
```
# Choose a choice in 10 seconds, but use the choice at
# index 1 instead of the one at index 0 when time runs out
choose in 10 seconds default 1
```
You can also use expressions in choose statements. For example:
```
choose getChoices() in baseTime + additionalTime seconds default foobar()
```