### PR TITLE
Add one-line comment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Cancel` and `Finish` methods to Rumor
 - Added `CancelCount` and `FinishCount` properties to Rumor
 - Added a `Choose` node
+- Added the ability to use one-line comments
 
 ### Changed
 - Added `SetupDefaultBindings` convenience method to Rumor for common bindings

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -82,6 +82,9 @@ namespace Exodrifter.Rumor.Lang
 
 		public IEnumerable<Node> Compile(string code)
 		{
+			var commentRegex = new Regex(@"^\s*#.*$", RegexOptions.Multiline);
+			code = commentRegex.Replace(code, "");
+
 			var tokens = cleaner.Clean(tokenizer.Tokenize(code));
 			var lines = new List<LogicalLine>(parser.Parse(tokens));
 


### PR DESCRIPTION
Only lines that start with a `#` are considered to be comments. For example, the following will be evaluated as comments:
```
# This is a comment
```
```
    # This is a comment, too
```
These lines will fail to compile:
```
say "Hello world!" # This comment doesn't work
```
```
say "Foobar!" # Nor this one.
```
The comments are evaluated as a pre-processing step before the compiler attempts to tokenize the string.