### PR TITLE
Fix improper null value handling in Expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - AutoAdvance is now a time instead of a toggle, which indicates the amount of
-  time before the Rumor will attempt to automatically advance.
+  time before the Rumor will attempt to automatically advance
 - Bindings are now stored in the Rumor instead of the Scope
+
+### Fixed
+- Fix bug where null variables are not handled properly in expressions
 
 
 ## [0.2.0] - 2016-11-05

--- a/Editor/Tests/Expressions/NullExpressions.cs
+++ b/Editor/Tests/Expressions/NullExpressions.cs
@@ -1,0 +1,316 @@
+﻿using Exodrifter.Rumor.Expressions;
+using NUnit.Framework;
+using System;
+
+namespace Exodrifter.Rumor.Test.Expressions
+{
+	/// <summary>
+	/// Ensure expressions work as expected when provided null values.
+	/// </summary>
+	public class NullExpressionsTest
+	{
+		/// <summary>
+		/// Tests operations with null and bool values.
+		/// </summary>
+		[Test]
+		public void NullAndBool()
+		{
+			var rumor = new Rumor.Engine.Rumor("return");
+			rumor.Scope.SetVar("a", true);
+
+			Expression exp = new AddExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new AddExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new SubtractExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new SubtractExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new MultiplyExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new MultiplyExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new DivideExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new DivideExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new BoolAndExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+			exp = new BoolAndExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+
+			exp = new BoolOrExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+			exp = new BoolOrExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+		}
+
+		/// <summary>
+		/// Tests operations with null and int values.
+		/// </summary>
+		[Test]
+		public void NullAndInt()
+		{
+			var rumor = new Rumor.Engine.Rumor("return");
+			rumor.Scope.SetVar("a", 1);
+
+			Expression exp = new AddExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(1, exp.Evaluate(rumor).AsInt());
+			exp = new AddExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(1, exp.Evaluate(rumor).AsInt());
+
+			exp = new SubtractExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(1, exp.Evaluate(rumor).AsInt());
+			exp = new SubtractExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(-1, exp.Evaluate(rumor).AsInt());
+
+			exp = new MultiplyExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(0, exp.Evaluate(rumor).AsInt());
+			exp = new MultiplyExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(0, exp.Evaluate(rumor).AsInt());
+
+			exp = new DivideExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(0, exp.Evaluate(rumor).AsInt());
+			exp = new DivideExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(0, exp.Evaluate(rumor).AsInt());
+
+			exp = new BoolAndExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+			exp = new BoolAndExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+
+			exp = new BoolOrExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+			exp = new BoolOrExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+		}
+
+		/// <summary>
+		/// Tests operations with null and float values.
+		/// </summary>
+		[Test]
+		public void NullAndFloat()
+		{
+			var rumor = new Rumor.Engine.Rumor("return");
+			rumor.Scope.SetVar("a", 1f);
+
+			Expression exp = new AddExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(1f, exp.Evaluate(rumor).AsFloat());
+			exp = new AddExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(1f, exp.Evaluate(rumor).AsFloat());
+
+			exp = new SubtractExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(1f, exp.Evaluate(rumor).AsFloat());
+			exp = new SubtractExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(-1f, exp.Evaluate(rumor).AsFloat());
+
+			exp = new MultiplyExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(0f, exp.Evaluate(rumor).AsFloat());
+			exp = new MultiplyExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(0f, exp.Evaluate(rumor).AsFloat());
+
+			exp = new DivideExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(0f, exp.Evaluate(rumor).AsFloat());
+			exp = new DivideExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(0f, exp.Evaluate(rumor).AsFloat());
+
+			exp = new BoolAndExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+			exp = new BoolAndExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+
+			exp = new BoolOrExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+			exp = new BoolOrExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+		}
+
+		/// <summary>
+		/// Tests operations with null and string values.
+		/// </summary>
+		[Test]
+		public void NullAndString()
+		{
+			var rumor = new Rumor.Engine.Rumor("return");
+			rumor.Scope.SetVar("a", "1");
+
+			Expression exp = new AddExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual("1", exp.Evaluate(rumor).AsString());
+			exp = new AddExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual("1", exp.Evaluate(rumor).AsString());
+
+			exp = new SubtractExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new SubtractExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new MultiplyExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new MultiplyExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new DivideExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+			exp = new DivideExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.Throws<InvalidOperationException>(() => exp.Evaluate(rumor).AsString());
+
+			exp = new BoolAndExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+			exp = new BoolAndExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(false, exp.Evaluate(rumor).AsBool());
+
+			exp = new BoolOrExpression(
+				new VariableExpression("a"),
+				new VariableExpression("b")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+			exp = new BoolOrExpression(
+				new VariableExpression("b"),
+				new VariableExpression("a")
+			);
+			Assert.AreEqual(true, exp.Evaluate(rumor).AsBool());
+		}
+	}
+}

--- a/Editor/Tests/Expressions/ValueTest.cs
+++ b/Editor/Tests/Expressions/ValueTest.cs
@@ -9,6 +9,14 @@ namespace Exodrifter.Rumor.Test.Expressions
 	/// </summary>
 	public class ValueTest
 	{
+		class Foo
+		{
+			public override string ToString ()
+			{
+				return "";
+			}
+		}
+
 		/// <summary>
 		/// Check the constructors of Values.
 		/// </summary>
@@ -42,7 +50,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var c = new FloatValue(1.0f);
 			var d = new StringValue("1");
 			var e = new BoolValue(true);
-			var f = new ObjectValue(null);
+			var f = new ObjectValue(new Foo());
 
 			Assert.AreEqual(a, a);
 			Assert.AreEqual(b, b);
@@ -74,7 +82,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(true);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.Not().AsBool(), false);
 			Assert.AreEqual(@float.Not().AsBool(), false);
@@ -93,7 +101,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(true);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.Add(@int).AsInt(), 2);
 			Assert.AreEqual(@int.Add(@float).AsFloat(), 2.0f);
@@ -136,7 +144,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(true);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.Subtract(@int).AsInt(), 0);
 			Assert.AreEqual(@int.Subtract(@float).AsFloat(), 0f);
@@ -179,7 +187,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(true);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.Multiply(@int).AsInt(), 1);
 			Assert.AreEqual(@int.Multiply(@float).AsFloat(), 1f);
@@ -222,7 +230,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(true);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.Divide(@int).AsInt(), 1);
 			Assert.AreEqual(@int.Divide(@float).AsFloat(), 1f);
@@ -265,7 +273,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(false);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.BoolAnd(@int).AsBool(), true);
 			Assert.AreEqual(@int.BoolAnd(@float).AsBool(), true);
@@ -308,7 +316,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(false);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.BoolOr(@int).AsBool(), true);
 			Assert.AreEqual(@int.BoolOr(@float).AsBool(), true);
@@ -351,7 +359,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @float = new FloatValue(1.0f);
 			var @string = new StringValue("1");
 			var @bool = new BoolValue(false);
-			var @obj = new ObjectValue(null);
+			var @obj = new ObjectValue(new Foo());
 
 			Assert.AreEqual(@int.BoolXor(@int).AsBool(), false);
 			Assert.AreEqual(@int.BoolXor(@float).AsBool(), false);

--- a/Expressions/AddExpression.cs
+++ b/Expressions/AddExpression.cs
@@ -17,8 +17,9 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
+
 			return l.Add(r);
 		}
 

--- a/Expressions/BoolAndExpression.cs
+++ b/Expressions/BoolAndExpression.cs
@@ -17,8 +17,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return l.BoolAnd(r);
 		}
 

--- a/Expressions/BoolOrExpression.cs
+++ b/Expressions/BoolOrExpression.cs
@@ -17,8 +17,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return l.BoolOr(r);
 		}
 

--- a/Expressions/BoolXorOperator.cs
+++ b/Expressions/BoolXorOperator.cs
@@ -17,8 +17,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return l.BoolXor(r);
 		}
 

--- a/Expressions/DivideExpression.cs
+++ b/Expressions/DivideExpression.cs
@@ -17,8 +17,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return l.Divide(r);
 		}
 

--- a/Expressions/MultiplyExpression.cs
+++ b/Expressions/MultiplyExpression.cs
@@ -17,8 +17,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return l.Multiply(r);
 		}
 

--- a/Expressions/NotEqualsExpression.cs
+++ b/Expressions/NotEqualsExpression.cs
@@ -18,8 +18,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return new BoolValue(!l.Equals(r));
 		}
 

--- a/Expressions/SubtractExpression.cs
+++ b/Expressions/SubtractExpression.cs
@@ -17,8 +17,8 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Evaluate(Engine.Rumor rumor)
 		{
-			var l = left.Evaluate(rumor);
-			var r = right.Evaluate(rumor);
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
 			return l.Subtract(r);
 		}
 

--- a/Expressions/Value/BoolValue.cs
+++ b/Expressions/Value/BoolValue.cs
@@ -19,7 +19,7 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Add(Value value)
 		{
 			if (value == null) {
-				return new BoolValue(AsBool());
+				throw new InvalidOperationException();
 			}
 			if (value.IsString()) {
 				var @bool = AsBool().ToString().ToLower();
@@ -48,6 +48,9 @@ namespace Exodrifter.Rumor.Expressions
 			if (value == null) {
 				return new BoolValue(false);
 			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new BoolValue(false);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsBool() && value.AsInt() != 0);
 			}
@@ -66,6 +69,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value BoolOr(Value value)
 		{
 			if (value == null) {
+				return new BoolValue(AsBool());
+			}
+			if (value.IsObject() && value.AsObject() == null) {
 				return new BoolValue(AsBool());
 			}
 			if (value.IsInt()) {

--- a/Expressions/Value/FloatValue.cs
+++ b/Expressions/Value/FloatValue.cs
@@ -19,7 +19,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Add(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new FloatValue(AsFloat());
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new FloatValue(AsFloat());
 			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() + value.AsInt());
@@ -36,7 +39,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Subtract(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new FloatValue(AsFloat());
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new FloatValue(AsFloat());
 			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() - value.AsInt());
@@ -50,7 +56,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Multiply(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new FloatValue(0);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new FloatValue(0);
 			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() * value.AsInt());
@@ -64,7 +73,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Divide(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new FloatValue(0);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new FloatValue(0);
 			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() / value.AsInt());
@@ -78,6 +90,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value BoolAnd(Value value)
 		{
 			if (value == null) {
+				return new BoolValue(false);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
 				return new BoolValue(false);
 			}
 			if (value.IsInt()) {
@@ -98,6 +113,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value BoolOr(Value value)
 		{
 			if (value == null) {
+				return new BoolValue(AsFloat() != 0);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
 				return new BoolValue(AsFloat() != 0);
 			}
 			if (value.IsInt()) {

--- a/Expressions/Value/IntValue.cs
+++ b/Expressions/Value/IntValue.cs
@@ -19,7 +19,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Add(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new IntValue(AsInt());
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new IntValue(AsInt());
 			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() + value.AsInt());
@@ -36,7 +39,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Subtract(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new IntValue(AsInt());
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new IntValue(AsInt());
 			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() - value.AsInt());
@@ -50,7 +56,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Multiply(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new IntValue(0);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new IntValue(0);
 			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() * value.AsInt());
@@ -64,7 +73,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Divide(Value value)
 		{
 			if (value == null) {
-				throw new InvalidOperationException();
+				return new IntValue(0);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new IntValue(0);
 			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() / value.AsInt());
@@ -78,6 +90,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value BoolAnd(Value value)
 		{
 			if (value == null) {
+				return new BoolValue(false);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
 				return new BoolValue(false);
 			}
 			if (value.IsInt()) {
@@ -98,6 +113,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value BoolOr(Value value)
 		{
 			if (value == null) {
+				return new BoolValue(AsInt() != 0);
+			}
+			if (value.IsObject() && value.AsObject() == null) {
 				return new BoolValue(AsInt() != 0);
 			}
 			if (value.IsInt()) {

--- a/Expressions/Value/ObjectValue.cs
+++ b/Expressions/Value/ObjectValue.cs
@@ -13,11 +13,25 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Not()
 		{
+			if (AsObject() == null) {
+				return new BoolValue(true);
+			}
 			throw new InvalidOperationException();
 		}
 
 		public override Value Add(Value value)
 		{
+			if (AsObject() == null) {
+				if (value == null) {
+					return new ObjectValue(null);
+				}
+				if (value.IsInt()) {
+					return new IntValue(value.AsInt());
+				}
+				if (value.IsFloat()) {
+					return new FloatValue(value.AsFloat());
+				}
+			}
 			if (value == null) {
 				throw new InvalidOperationException();
 			}
@@ -29,26 +43,91 @@ namespace Exodrifter.Rumor.Expressions
 
 		public override Value Subtract(Value value)
 		{
+			if (AsObject() == null) {
+				if (value == null) {
+					return new ObjectValue(null);
+				}
+				if (value.IsInt()) {
+					return new IntValue(0 - value.AsInt());
+				}
+				if (value.IsFloat()) {
+					return new FloatValue(0 - value.AsFloat());
+				}
+				if (value.IsObject() && value.AsObject() == null) {
+					return new ObjectValue(null);
+				}
+			}
 			throw new InvalidOperationException();
 		}
 
 		public override Value Multiply(Value value)
 		{
+			if (AsObject() == null) {
+				if (value == null) {
+					return new ObjectValue(null);
+				}
+				if (value.IsInt()) {
+					return new IntValue(0);
+				}
+				if (value.IsFloat()) {
+					return new FloatValue(0);
+				}
+				if (value.IsObject() && value.AsObject() == null) {
+					return new ObjectValue(null);
+				}
+			}
 			throw new InvalidOperationException();
 		}
 
 		public override Value Divide(Value value)
 		{
+			if (AsObject() == null) {
+				if (value == null) {
+					return new ObjectValue(null);
+				}
+				if (value.IsInt()) {
+					return new IntValue(0);
+				}
+				if (value.IsFloat()) {
+					return new FloatValue(0);
+				}
+				if (value.IsObject() && value.AsObject() == null) {
+					return new ObjectValue(null);
+				}
+			}
 			throw new InvalidOperationException();
 		}
 
 		public override Value BoolAnd(Value value)
 		{
+			if (AsObject() == null) {
+				return new BoolValue(false);
+			}
 			throw new InvalidOperationException();
 		}
 
 		public override Value BoolOr(Value value)
 		{
+			if (AsObject() == null) {
+				if (value == null) {
+					return new BoolValue(false);
+				}
+				if (value.IsBool()) {
+					return new BoolValue(value.AsBool());
+				}
+				else if (value.IsInt()) {
+					return new BoolValue(value.AsInt() != 0);
+				}
+				else if (value.IsFloat()) {
+					return new BoolValue(value.AsFloat() != 0);
+				}
+				else if (value.IsString()) {
+					return new BoolValue(value.AsString() != "");
+				}
+				else if (value.AsObject() == null) {
+					return new BoolValue(false);
+				}
+			}
 			throw new InvalidOperationException();
 		}
 

--- a/Expressions/Value/StringValue.cs
+++ b/Expressions/Value/StringValue.cs
@@ -60,6 +60,9 @@ namespace Exodrifter.Rumor.Expressions
 			if (value == null) {
 				return new BoolValue(false);
 			}
+			if (value.IsObject() && value.AsObject() == null) {
+				return new BoolValue(false);
+			}
 			if (value.IsInt()) {
 				return new BoolValue(AsString() != "" && value.AsInt() != 0);
 			}
@@ -78,6 +81,9 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value BoolOr(Value value)
 		{
 			if (value == null) {
+				return new BoolValue(AsString() != "");
+			}
+			if (value.IsObject() && value.AsObject() == null) {
 				return new BoolValue(AsString() != "");
 			}
 			if (value.IsInt()) {

--- a/Expressions/Value/Value.cs
+++ b/Expressions/Value/Value.cs
@@ -65,6 +65,18 @@ namespace Exodrifter.Rumor.Expressions
 		}
 
 		/// <summary>
+		/// Returns true if this value is not a boolean, integer, float, or
+		/// string.
+		/// </summary>
+		/// <returns>
+		/// True if this value is not a boolean, integer, float, or string.
+		/// </returns>
+		public bool IsObject()
+		{
+			return !IsBool() && !IsInt() && !IsFloat() && !IsString();
+		}
+
+		/// <summary>
 		/// Returns this value as a bool.
 		/// </summary>
 		/// <param name="val">


### PR DESCRIPTION
Fix improper null handling in Expressions by:

* Making expressions more null resistant by null coalescing
* Making value operator methods more null resistant by checking for null
* Making value operator methods handle null object values