### PR TITLE
Fix unit tests that mix expected and actual

### DIFF
--- a/Editor/Tests/Expressions/FunctionTest.cs
+++ b/Editor/Tests/Expressions/FunctionTest.cs
@@ -24,32 +24,32 @@ namespace Exodrifter.Rumor.Test.Expressions
 			int a1 = 0;
 			rumor.Bind("a1", (int p1) => a1 = p1);
 			rumor.CallBinding("a1", 1);
-			Assert.AreEqual(a1, 1);
+			Assert.AreEqual(1, a1);
 
 			int a2 = 0;
 			rumor.Bind("a2", (int p1, int p2) => { a1 = p1; a2 = p2; });
 			rumor.CallBinding("a2", 2, 3);
-			Assert.AreEqual(a1, 2);
-			Assert.AreEqual(a2, 3);
+			Assert.AreEqual(2, a1);
+			Assert.AreEqual(3, a2);
 
 			int a3 = 0;
 			rumor.Bind("a3", (int p1, int p2, int p3) => {
 				a1 = p1; a2 = p2; a3 = p3;
 			});
 			rumor.CallBinding("a3", 3, 4, 5);
-			Assert.AreEqual(a1, 3);
-			Assert.AreEqual(a2, 4);
-			Assert.AreEqual(a3, 5);
+			Assert.AreEqual(3, a1);
+			Assert.AreEqual(4, a2);
+			Assert.AreEqual(5, a3);
 
 			int a4 = 0;
 			rumor.Bind("a4", (int p1, int p2, int p3, int p4) => {
 				a1 = p1; a2 = p2; a3 = p3; a4 = p4;
 			});
 			rumor.CallBinding("a4", 4, 5, 6, 7);
-			Assert.AreEqual(a1, 4);
-			Assert.AreEqual(a2, 5);
-			Assert.AreEqual(a3, 6);
-			Assert.AreEqual(a4, 7);
+			Assert.AreEqual(4, a1);
+			Assert.AreEqual(5, a2);
+			Assert.AreEqual(6, a3);
+			Assert.AreEqual(7, a4);
 		}
 
 		/// <summary>
@@ -66,23 +66,23 @@ namespace Exodrifter.Rumor.Test.Expressions
 
 			rumor.Bind("a1", (int p1) => { return p1; });
 			var a1 = rumor.CallBinding("a1", 1);
-			Assert.AreEqual(a1, 1);
+			Assert.AreEqual(1, a1);
 
 			rumor.Bind("a2", (int p1, int p2) => { return p1 + p2; });
 			var a2 = rumor.CallBinding("a2", 1, 2);
-			Assert.AreEqual(a2, 3);
+			Assert.AreEqual(3, a2);
 
 			rumor.Bind("a3", (int p1, int p2, int p3) => {
 				return p1 + p2 + p3;
 			});
 			var a3 = rumor.CallBinding("a3", 1, 2, 3);
-			Assert.AreEqual(a3, 6);
+			Assert.AreEqual(6, a3);
 
 			rumor.Bind("a4", (int p1, int p2, int p3, int p4) => {
 				return p1 + p2 + p3 + p4;
 			});
 			var a4 = rumor.CallBinding("a4", 1, 2, 3, 5);
-			Assert.AreEqual(a4, 11);
+			Assert.AreEqual(11, a4);
 		}
 
 		[Test]

--- a/Editor/Tests/Expressions/ValueTest.cs
+++ b/Editor/Tests/Expressions/ValueTest.cs
@@ -16,19 +16,19 @@ namespace Exodrifter.Rumor.Test.Expressions
 		public void ValueConstructor()
 		{
 			var @int = new IntValue(1);
-			Assert.AreEqual(@int.AsInt(), 1);
+			Assert.AreEqual(1, @int.AsInt());
 
 			var @float = new FloatValue(1.0f);
-			Assert.AreEqual(@float.AsFloat(), 1.0f);
+			Assert.AreEqual(1.0f, @float.AsFloat());
 
 			var @string = new StringValue("1");
-			Assert.AreEqual(@string.AsString(), "1");
+			Assert.AreEqual("1", @string.AsString());
 
 			var @bool = new BoolValue(true);
-			Assert.AreEqual(@bool.AsBool(), true);
+			Assert.AreEqual(true, @bool.AsBool());
 
 			var @obj = new ObjectValue(null);
-			Assert.AreEqual(@obj.AsObject(), null);
+			Assert.AreEqual(null, @obj.AsObject());
 		}
 
 		/// <summary>
@@ -76,10 +76,10 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.Not().AsBool(), false);
-			Assert.AreEqual(@float.Not().AsBool(), false);
-			Assert.AreEqual(@string.Not().AsBool(), false);
-			Assert.AreEqual(@bool.Not().AsBool(), false);
+			Assert.AreEqual(false, @int.Not().AsBool());
+			Assert.AreEqual(false, @float.Not().AsBool());
+			Assert.AreEqual(false, @string.Not().AsBool());
+			Assert.AreEqual(false, @bool.Not().AsBool());
 			Assert.Catch<InvalidOperationException>(() => @obj.Not());
 		}
 
@@ -95,33 +95,33 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.Add(@int).AsInt(), 2);
-			Assert.AreEqual(@int.Add(@float).AsFloat(), 2.0f);
-			Assert.AreEqual(@int.Add(@string).AsString(), "11");
+			Assert.AreEqual(2, @int.Add(@int).AsInt());
+			Assert.AreEqual(2.0f, @int.Add(@float).AsFloat());
+			Assert.AreEqual("11", @int.Add(@string).AsString());
 			Assert.Catch<InvalidOperationException>(() => @int.Add(@bool));
 			Assert.Catch<InvalidOperationException>(() => @int.Add(@obj));
 
-			Assert.AreEqual(@float.Add(@int).AsFloat(), 2.0f);
-			Assert.AreEqual(@float.Add(@float).AsFloat(), 2.0f);
-			Assert.AreEqual(@float.Add(@string).AsString(), "11");
+			Assert.AreEqual(2.0f, @float.Add(@int).AsFloat());
+			Assert.AreEqual(2.0f, @float.Add(@float).AsFloat(), 2.0f);
+			Assert.AreEqual("11", @float.Add(@string).AsString(), "11");
 			Assert.Catch<InvalidOperationException>(() => @float.Add(@bool));
 			Assert.Catch<InvalidOperationException>(() => @float.Add(@obj));
 
-			Assert.AreEqual(@string.Add(@int).AsString(), "11");
-			Assert.AreEqual(@string.Add(@float).AsString(), "11");
-			Assert.AreEqual(@string.Add(@string).AsString(), "11");
-			Assert.AreEqual(@string.Add(@bool).AsString(), "1true");
-			Assert.AreEqual(@string.Add(@obj).AsString(), "1");
+			Assert.AreEqual("11", @string.Add(@int).AsString());
+			Assert.AreEqual("11", @string.Add(@float).AsString());
+			Assert.AreEqual("11", @string.Add(@string).AsString());
+			Assert.AreEqual("1true", @string.Add(@bool).AsString());
+			Assert.AreEqual("1", @string.Add(@obj).AsString());
 
 			Assert.Catch<InvalidOperationException>(() => @bool.Add(@int));
 			Assert.Catch<InvalidOperationException>(() => @bool.Add(@float));
-			Assert.AreEqual(@bool.Add(@string).AsString(), "true1");
+			Assert.AreEqual("true1", @bool.Add(@string).AsString());
 			Assert.Catch<InvalidOperationException>(() => @bool.Add(@bool));
 			Assert.Catch<InvalidOperationException>(() => @bool.Add(@obj));
 
 			Assert.Catch<InvalidOperationException>(() => @obj.Add(@int));
 			Assert.Catch<InvalidOperationException>(() => @obj.Add(@float));
-			Assert.AreEqual(@obj.Add(@string).AsString(), "1");
+			Assert.AreEqual("1", @obj.Add(@string).AsString());
 			Assert.Catch<InvalidOperationException>(() => @obj.Add(@bool));
 			Assert.Catch<InvalidOperationException>(() => @obj.Add(@obj));
 		}
@@ -138,14 +138,14 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.Subtract(@int).AsInt(), 0);
-			Assert.AreEqual(@int.Subtract(@float).AsFloat(), 0f);
+			Assert.AreEqual(0, @int.Subtract(@int).AsInt());
+			Assert.AreEqual(0f, @int.Subtract(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @int.Subtract(@string));
 			Assert.Catch<InvalidOperationException>(() => @int.Subtract(@bool));
 			Assert.Catch<InvalidOperationException>(() => @int.Subtract(@obj));
 
-			Assert.AreEqual(@float.Subtract(@int).AsFloat(), 0f);
-			Assert.AreEqual(@float.Subtract(@float).AsFloat(), 0f);
+			Assert.AreEqual(0f, @float.Subtract(@int).AsFloat());
+			Assert.AreEqual(0f, @float.Subtract(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @float.Subtract(@string));
 			Assert.Catch<InvalidOperationException>(() => @float.Subtract(@bool));
 			Assert.Catch<InvalidOperationException>(() => @float.Subtract(@obj));
@@ -181,14 +181,14 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.Multiply(@int).AsInt(), 1);
-			Assert.AreEqual(@int.Multiply(@float).AsFloat(), 1f);
+			Assert.AreEqual(1, @int.Multiply(@int).AsInt());
+			Assert.AreEqual(1f, @int.Multiply(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @int.Multiply(@string));
 			Assert.Catch<InvalidOperationException>(() => @int.Multiply(@bool));
 			Assert.Catch<InvalidOperationException>(() => @int.Multiply(@obj));
 
-			Assert.AreEqual(@float.Multiply(@int).AsFloat(), 1f);
-			Assert.AreEqual(@float.Multiply(@float).AsFloat(), 1f);
+			Assert.AreEqual(1f, @float.Multiply(@int).AsFloat());
+			Assert.AreEqual(1f, @float.Multiply(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @float.Multiply(@string));
 			Assert.Catch<InvalidOperationException>(() => @float.Multiply(@bool));
 			Assert.Catch<InvalidOperationException>(() => @float.Multiply(@obj));
@@ -224,14 +224,14 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.Divide(@int).AsInt(), 1);
-			Assert.AreEqual(@int.Divide(@float).AsFloat(), 1f);
+			Assert.AreEqual(1, @int.Divide(@int).AsInt());
+			Assert.AreEqual(1f, @int.Divide(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @int.Divide(@string));
 			Assert.Catch<InvalidOperationException>(() => @int.Divide(@bool));
 			Assert.Catch<InvalidOperationException>(() => @int.Divide(@obj));
 
-			Assert.AreEqual(@float.Divide(@int).AsFloat(), 1f);
-			Assert.AreEqual(@float.Divide(@float).AsFloat(), 1f);
+			Assert.AreEqual(1f, @float.Divide(@int).AsFloat());
+			Assert.AreEqual(1f, @float.Divide(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @float.Divide(@string));
 			Assert.Catch<InvalidOperationException>(() => @float.Divide(@bool));
 			Assert.Catch<InvalidOperationException>(() => @float.Divide(@obj));
@@ -267,28 +267,28 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(false);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.BoolAnd(@int).AsBool(), true);
-			Assert.AreEqual(@int.BoolAnd(@float).AsBool(), true);
-			Assert.AreEqual(@int.BoolAnd(@string).AsBool(), true);
-			Assert.AreEqual(@int.BoolAnd(@bool).AsBool(), false);
+			Assert.AreEqual(true, @int.BoolAnd(@int).AsBool());
+			Assert.AreEqual(true, @int.BoolAnd(@float).AsBool());
+			Assert.AreEqual(true, @int.BoolAnd(@string).AsBool());
+			Assert.AreEqual(false, @int.BoolAnd(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @int.BoolAnd(@obj));
 
-			Assert.AreEqual(@float.BoolAnd(@int).AsBool(), true);
-			Assert.AreEqual(@float.BoolAnd(@float).AsBool(), true);
-			Assert.AreEqual(@float.BoolAnd(@string).AsBool(), true);
-			Assert.AreEqual(@float.BoolAnd(@bool).AsBool(), false);
+			Assert.AreEqual(true, @float.BoolAnd(@int).AsBool());
+			Assert.AreEqual(true, @float.BoolAnd(@float).AsBool());
+			Assert.AreEqual(true, @float.BoolAnd(@string).AsBool());
+			Assert.AreEqual(false, @float.BoolAnd(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @float.BoolAnd(@obj));
 
-			Assert.AreEqual(@string.BoolAnd(@int).AsBool(), true);
-			Assert.AreEqual(@string.BoolAnd(@float).AsBool(), true);
-			Assert.AreEqual(@string.BoolAnd(@string).AsBool(), true);
-			Assert.AreEqual(@string.BoolAnd(@bool).AsBool(), false);
+			Assert.AreEqual(true, @string.BoolAnd(@int).AsBool());
+			Assert.AreEqual(true, @string.BoolAnd(@float).AsBool());
+			Assert.AreEqual(true, @string.BoolAnd(@string).AsBool());
+			Assert.AreEqual(false, @string.BoolAnd(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @string.BoolAnd(@obj));
 
-			Assert.AreEqual(@bool.BoolAnd(@int).AsBool(), false);
-			Assert.AreEqual(@bool.BoolAnd(@float).AsBool(), false);
-			Assert.AreEqual(@bool.BoolAnd(@string).AsBool(), false);
-			Assert.AreEqual(@bool.BoolAnd(@bool).AsBool(), false);
+			Assert.AreEqual(false, @bool.BoolAnd(@int).AsBool());
+			Assert.AreEqual(false, @bool.BoolAnd(@float).AsBool());
+			Assert.AreEqual(false, @bool.BoolAnd(@string).AsBool());
+			Assert.AreEqual(false, @bool.BoolAnd(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @bool.BoolAnd(@obj));
 
 			Assert.Catch<InvalidOperationException>(() => @obj.BoolAnd(@int));
@@ -310,28 +310,28 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(false);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.BoolOr(@int).AsBool(), true);
-			Assert.AreEqual(@int.BoolOr(@float).AsBool(), true);
-			Assert.AreEqual(@int.BoolOr(@string).AsBool(), true);
-			Assert.AreEqual(@int.BoolOr(@bool).AsBool(), true);
+			Assert.AreEqual(true, @int.BoolOr(@int).AsBool());
+			Assert.AreEqual(true, @int.BoolOr(@float).AsBool());
+			Assert.AreEqual(true, @int.BoolOr(@string).AsBool());
+			Assert.AreEqual(true, @int.BoolOr(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @int.BoolAnd(@obj));
 
-			Assert.AreEqual(@float.BoolOr(@int).AsBool(), true);
-			Assert.AreEqual(@float.BoolOr(@float).AsBool(), true);
-			Assert.AreEqual(@float.BoolOr(@string).AsBool(), true);
-			Assert.AreEqual(@float.BoolOr(@bool).AsBool(), true);
+			Assert.AreEqual(true, @float.BoolOr(@int).AsBool());
+			Assert.AreEqual(true, @float.BoolOr(@float).AsBool());
+			Assert.AreEqual(true, @float.BoolOr(@string).AsBool());
+			Assert.AreEqual(true, @float.BoolOr(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @float.BoolAnd(@obj));
 
-			Assert.AreEqual(@string.BoolOr(@int).AsBool(), true);
-			Assert.AreEqual(@string.BoolOr(@float).AsBool(), true);
-			Assert.AreEqual(@string.BoolOr(@string).AsBool(), true);
-			Assert.AreEqual(@string.BoolOr(@bool).AsBool(), true);
+			Assert.AreEqual(true, @string.BoolOr(@int).AsBool());
+			Assert.AreEqual(true, @string.BoolOr(@float).AsBool());
+			Assert.AreEqual(true, @string.BoolOr(@string).AsBool());
+			Assert.AreEqual(true, @string.BoolOr(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @string.BoolAnd(@obj));
 
-			Assert.AreEqual(@bool.BoolOr(@int).AsBool(), true);
-			Assert.AreEqual(@bool.BoolOr(@float).AsBool(), true);
-			Assert.AreEqual(@bool.BoolOr(@string).AsBool(), true);
-			Assert.AreEqual(@bool.BoolOr(@bool).AsBool(), false);
+			Assert.AreEqual(true, @bool.BoolOr(@int).AsBool());
+			Assert.AreEqual(true, @bool.BoolOr(@float).AsBool());
+			Assert.AreEqual(true, @bool.BoolOr(@string).AsBool());
+			Assert.AreEqual(false, @bool.BoolOr(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @bool.BoolAnd(@obj));
 
 			Assert.Catch<InvalidOperationException>(() => @obj.BoolOr(@int));
@@ -353,28 +353,28 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(false);
 			var @obj = new ObjectValue(null);
 
-			Assert.AreEqual(@int.BoolXor(@int).AsBool(), false);
-			Assert.AreEqual(@int.BoolXor(@float).AsBool(), false);
-			Assert.AreEqual(@int.BoolXor(@string).AsBool(), false);
-			Assert.AreEqual(@int.BoolXor(@bool).AsBool(), true);
+			Assert.AreEqual(false, @int.BoolXor(@int).AsBool());
+			Assert.AreEqual(false, @int.BoolXor(@float).AsBool());
+			Assert.AreEqual(false, @int.BoolXor(@string).AsBool());
+			Assert.AreEqual(true, @int.BoolXor(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @int.BoolAnd(@obj));
 
-			Assert.AreEqual(@float.BoolXor(@int).AsBool(), false);
-			Assert.AreEqual(@float.BoolXor(@float).AsBool(), false);
-			Assert.AreEqual(@float.BoolXor(@string).AsBool(), false);
-			Assert.AreEqual(@float.BoolXor(@bool).AsBool(), true);
+			Assert.AreEqual(false, @float.BoolXor(@int).AsBool());
+			Assert.AreEqual(false, @float.BoolXor(@float).AsBool());
+			Assert.AreEqual(false, @float.BoolXor(@string).AsBool());
+			Assert.AreEqual(true, @float.BoolXor(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @float.BoolAnd(@obj));
 
-			Assert.AreEqual(@string.BoolXor(@int).AsBool(), false);
-			Assert.AreEqual(@string.BoolXor(@float).AsBool(), false);
-			Assert.AreEqual(@string.BoolXor(@string).AsBool(), false);
-			Assert.AreEqual(@string.BoolXor(@bool).AsBool(), true);
+			Assert.AreEqual(false, @string.BoolXor(@int).AsBool());
+			Assert.AreEqual(false, @string.BoolXor(@float).AsBool());
+			Assert.AreEqual(false, @string.BoolXor(@string).AsBool());
+			Assert.AreEqual(true, @string.BoolXor(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @string.BoolAnd(@obj));
 
-			Assert.AreEqual(@bool.BoolXor(@int).AsBool(), true);
-			Assert.AreEqual(@bool.BoolXor(@float).AsBool(), true);
-			Assert.AreEqual(@bool.BoolXor(@string).AsBool(), true);
-			Assert.AreEqual(@bool.BoolXor(@bool).AsBool(), false);
+			Assert.AreEqual(true, @bool.BoolXor(@int).AsBool());
+			Assert.AreEqual(true, @bool.BoolXor(@float).AsBool());
+			Assert.AreEqual(true, @bool.BoolXor(@string).AsBool());
+			Assert.AreEqual(false, @bool.BoolXor(@bool).AsBool());
 			Assert.Catch<InvalidOperationException>(() => @bool.BoolAnd(@obj));
 
 			Assert.Catch<InvalidOperationException>(() => @obj.BoolXor(@int));

--- a/Editor/Tests/Lang/CleanerTest.cs
+++ b/Editor/Tests/Lang/CleanerTest.cs
@@ -26,15 +26,15 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var tokens = new List<LogicalToken>(cleaner.Clean(input));
 
-			Assert.AreEqual(tokens.Count, 2);
+			Assert.AreEqual(2, tokens.Count);
 
-			Assert.AreEqual(tokens[0].text, "a");
-			Assert.AreEqual(tokens[0].row, 0);
-			Assert.AreEqual(tokens[0].col, 0);
+			Assert.AreEqual("a", tokens[0].text);
+			Assert.AreEqual(0, tokens[0].row);
+			Assert.AreEqual(0, tokens[0].col);
 
-			Assert.AreEqual(tokens[1].text, "c");
-			Assert.AreEqual(tokens[1].row, 0);
-			Assert.AreEqual(tokens[1].col, 2);
+			Assert.AreEqual("c", tokens[1].text);
+			Assert.AreEqual(0, tokens[1].row);
+			Assert.AreEqual(2, tokens[1].col);
 		}
 
 		/// <summary>
@@ -58,7 +58,7 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var tokens = new List<LogicalToken>(cleaner.Clean(input));
 
-			Assert.AreEqual(tokens.Count, 0);
+			Assert.AreEqual(0, tokens.Count);
 		}
 
 		/// <summary>
@@ -81,11 +81,11 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var tokens = new List<LogicalToken>(cleaner.Clean(input));
 
-			Assert.AreEqual(tokens.Count, 1);
+			Assert.AreEqual(1, tokens.Count);
 
-			Assert.AreEqual(tokens[0].text, "\n");
-			Assert.AreEqual(tokens[0].row, 0);
-			Assert.AreEqual(tokens[0].col, 0);
+			Assert.AreEqual("\n", tokens[0].text);
+			Assert.AreEqual(0, tokens[0].row);
+			Assert.AreEqual(0, tokens[0].col);
 		}
 
 		/// <summary>
@@ -108,19 +108,19 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var tokens = new List<LogicalToken>(cleaner.Clean(input));
 
-			Assert.AreEqual(tokens.Count, 3);
+			Assert.AreEqual(3, tokens.Count);
 
-			Assert.AreEqual(tokens[0].text, "\n");
-			Assert.AreEqual(tokens[0].row, 0);
-			Assert.AreEqual(tokens[0].col, 0);
+			Assert.AreEqual("\n", tokens[0].text);
+			Assert.AreEqual(0, tokens[0].row);
+			Assert.AreEqual(0, tokens[0].col);
 
-			Assert.AreEqual(tokens[1].text, "\n");
-			Assert.AreEqual(tokens[1].row, 1);
-			Assert.AreEqual(tokens[1].col, 0);
+			Assert.AreEqual("\n", tokens[1].text);
+			Assert.AreEqual(1, tokens[1].row);
+			Assert.AreEqual(0, tokens[1].col);
 
-			Assert.AreEqual(tokens[2].text, "\n");
-			Assert.AreEqual(tokens[2].row, 2);
-			Assert.AreEqual(tokens[2].col, 0);
+			Assert.AreEqual("\n", tokens[2].text);
+			Assert.AreEqual(2, tokens[2].row);
+			Assert.AreEqual(0, tokens[2].col);
 		}
 
 		/// <summary>
@@ -144,7 +144,7 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var tokens = new List<LogicalToken>(cleaner.Clean(input));
 
-			Assert.AreEqual(tokens.Count, 0);
+			Assert.AreEqual(0, tokens.Count);
 		}
 
 		/// <summary>
@@ -170,11 +170,11 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var tokens = new List<LogicalToken>(cleaner.Clean(input));
 
-			Assert.AreEqual(tokens.Count, 1);
+			Assert.AreEqual(1, tokens.Count);
 
-			Assert.AreEqual(tokens[0].text, "b");
-			Assert.AreEqual(tokens[0].row, 6);
-			Assert.AreEqual(tokens[0].col, 0);
+			Assert.AreEqual("b", tokens[0].text);
+			Assert.AreEqual(6, tokens[0].row);
+			Assert.AreEqual(0, tokens[0].col);
 		}
 	}
 }

--- a/Editor/Tests/Lang/CompilerTest.cs
+++ b/Editor/Tests/Lang/CompilerTest.cs
@@ -15,8 +15,8 @@ namespace Exodrifter.Rumor.Test.Lang
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			var rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Say).EvaluateText(rumor), "This is a multiline string.");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual("This is a multiline string.", (nodes[0] as Say).EvaluateText(rumor));
 		}
 
 		[Test]
@@ -26,8 +26,8 @@ namespace Exodrifter.Rumor.Test.Lang
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			var rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Say).EvaluateText(rumor), "This is a multiline string.");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual("This is a multiline string.", (nodes[0] as Say).EvaluateText(rumor));
 		}
 
 		[Test]
@@ -37,8 +37,8 @@ namespace Exodrifter.Rumor.Test.Lang
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			var rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Say).EvaluateText(rumor), "This is a multiline string.");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual("This is a multiline string.", (nodes[0] as Say).EvaluateText(rumor));
 		}
 
 		[Test]
@@ -48,8 +48,8 @@ namespace Exodrifter.Rumor.Test.Lang
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			var rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Say).EvaluateText(rumor), "This  is  a  multiline string.");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual("This  is  a  multiline string.", (nodes[0] as Say).EvaluateText(rumor));
 		}
 
 		[Test]
@@ -59,29 +59,29 @@ namespace Exodrifter.Rumor.Test.Lang
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			var rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat(), 0f);
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual(0f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause .5";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
 			
 			rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat(), 0.5f);
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual(0.5f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause 0.5";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat(), 0.5f);
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual(0.5f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause 1";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat(), 1f);
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual(1f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 		}
 
 		[Test]
@@ -92,15 +92,15 @@ namespace Exodrifter.Rumor.Test.Lang
 
 			var rumor = new Rumor.Engine.Rumor("return");
 			rumor.Bind("foo", () => { return 1f; });
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat(), 1f);
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual(1f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause 8.0 * 3.0";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
 
 			rumor = new Rumor.Engine.Rumor("return");
-			Assert.AreEqual(nodes.Count, 1);
-			Assert.AreEqual((nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat(), 24f);
+			Assert.AreEqual(1, nodes.Count);
+			Assert.AreEqual(24f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 		}
 	}
 }

--- a/Editor/Tests/Lang/ParserTest.cs
+++ b/Editor/Tests/Lang/ParserTest.cs
@@ -25,7 +25,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			var lTokens = tokens.Select(x => new LogicalToken(x));
 			var lines = new List<LogicalLine>(parser.Parse(lTokens));
 
-			Assert.AreEqual(lines.Count, 4);
+			Assert.AreEqual(4, lines.Count);
 		}
 
 		[Test]
@@ -45,8 +45,8 @@ namespace Exodrifter.Rumor.Test.Lang
 			var lTokens = tokens.Select(x => new LogicalToken(x));
 			var lines = new List<LogicalLine>(parser.Parse(lTokens));
 
-			Assert.AreEqual(lines.Count, 1);
-			Assert.AreEqual(lines[0].tokens.Count, tokens.Count);
+			Assert.AreEqual(1, lines.Count);
+			Assert.AreEqual(tokens.Count, lines[0].tokens.Count);
 		}
 	}
 }

--- a/Editor/Tests/Lang/TokenizerTest.cs
+++ b/Editor/Tests/Lang/TokenizerTest.cs
@@ -22,13 +22,13 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = " \r\n   ";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 6);
-			Assert.AreEqual(tokens[0], " ");
-			Assert.AreEqual(tokens[1], "\r");
-			Assert.AreEqual(tokens[2], "\n");
-			Assert.AreEqual(tokens[3], " ");
-			Assert.AreEqual(tokens[4], " ");
-			Assert.AreEqual(tokens[5], " ");
+			Assert.AreEqual(6, tokens.Count);
+			Assert.AreEqual(" ", tokens[0]);
+			Assert.AreEqual("\r", tokens[1]);
+			Assert.AreEqual("\n", tokens[2]);
+			Assert.AreEqual(" ", tokens[3]);
+			Assert.AreEqual(" ", tokens[4]);
+			Assert.AreEqual(" ", tokens[5]);
 		}
 
 		/// <summary>
@@ -47,11 +47,11 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = " \r\n\r\t";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 4);
-			Assert.AreEqual(tokens[0], " ");
-			Assert.AreEqual(tokens[1], "\r\n");
-			Assert.AreEqual(tokens[2], "\r");
-			Assert.AreEqual(tokens[3], "\t");
+			Assert.AreEqual(4, tokens.Count);
+			Assert.AreEqual(" ", tokens[0]);
+			Assert.AreEqual("\r\n", tokens[1]);
+			Assert.AreEqual("\r", tokens[2]);
+			Assert.AreEqual("\t", tokens[3]);
 		}
 
 		/// <summary>
@@ -70,11 +70,11 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = " \r\n\r\t";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 4);
-			Assert.AreEqual(tokens[0], " ");
-			Assert.AreEqual(tokens[1], "\r\n");
-			Assert.AreEqual(tokens[2], "\r");
-			Assert.AreEqual(tokens[3], "\t");
+			Assert.AreEqual(4, tokens.Count);
+			Assert.AreEqual(" ", tokens[0]);
+			Assert.AreEqual("\r\n", tokens[1]);
+			Assert.AreEqual("\r", tokens[2]);
+			Assert.AreEqual("\t", tokens[3]);
 		}
 
 		/// <summary>
@@ -93,11 +93,11 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = "    ";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 4);
-			Assert.AreEqual(tokens[0], " ");
-			Assert.AreEqual(tokens[1], " ");
-			Assert.AreEqual(tokens[2], " ");
-			Assert.AreEqual(tokens[3], " ");
+			Assert.AreEqual(4, tokens.Count);
+			Assert.AreEqual(" ", tokens[0]);
+			Assert.AreEqual(" ", tokens[1]);
+			Assert.AreEqual(" ", tokens[2]);
+			Assert.AreEqual(" ", tokens[3]);
 		}
 
 		/// <summary>
@@ -116,10 +116,10 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = "     ";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 3);
-			Assert.AreEqual(tokens[0], "  ");
-			Assert.AreEqual(tokens[1], "  ");
-			Assert.AreEqual(tokens[2], " ");
+			Assert.AreEqual(3, tokens.Count);
+			Assert.AreEqual("  ", tokens[0]);
+			Assert.AreEqual("  ", tokens[1]);
+			Assert.AreEqual(" ", tokens[2]);
 		}
 
 		/// <summary>
@@ -137,10 +137,10 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = "Hello, world!";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 3);
-			Assert.AreEqual(tokens[0], "Hello,");
-			Assert.AreEqual(tokens[1], " ");
-			Assert.AreEqual(tokens[2], "world!");
+			Assert.AreEqual(3, tokens.Count);
+			Assert.AreEqual("Hello,", tokens[0]);
+			Assert.AreEqual(" ", tokens[1]);
+			Assert.AreEqual("world!", tokens[2]);
 		}
 
 		/// <summary>
@@ -159,12 +159,12 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = "Hello, world!";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 5);
-			Assert.AreEqual(tokens[0], "Hello");
-			Assert.AreEqual(tokens[1], ",");
-			Assert.AreEqual(tokens[2], " ");
-			Assert.AreEqual(tokens[3], "world");
-			Assert.AreEqual(tokens[4], "!");
+			Assert.AreEqual(5, tokens.Count);
+			Assert.AreEqual("Hello", tokens[0]);
+			Assert.AreEqual(",", tokens[1]);
+			Assert.AreEqual(" ", tokens[2]);
+			Assert.AreEqual("world", tokens[3]);
+			Assert.AreEqual("!", tokens[4]);
 		}
 
 		/// <summary>
@@ -183,16 +183,16 @@ namespace Exodrifter.Rumor.Test.Lang
 			var input = "float a -> float b";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
 
-			Assert.AreEqual(tokens.Count, 9);
-			Assert.AreEqual(tokens[0], "float");
-			Assert.AreEqual(tokens[1], " ");
-			Assert.AreEqual(tokens[2], "a");
-			Assert.AreEqual(tokens[3], " ");
-			Assert.AreEqual(tokens[4], "->");
-			Assert.AreEqual(tokens[5], " ");
-			Assert.AreEqual(tokens[6], "float");
-			Assert.AreEqual(tokens[7], " ");
-			Assert.AreEqual(tokens[8], "b");
+			Assert.AreEqual(9, tokens.Count);
+			Assert.AreEqual("float", tokens[0]);
+			Assert.AreEqual(" ", tokens[1]);
+			Assert.AreEqual("a", tokens[2]);
+			Assert.AreEqual(" ", tokens[3]);
+			Assert.AreEqual("->", tokens[4]);
+			Assert.AreEqual(" ", tokens[5]);
+			Assert.AreEqual("float", tokens[6]);
+			Assert.AreEqual(" ", tokens[7]);
+			Assert.AreEqual("b", tokens[8]);
 		}
 	}
 }


### PR DESCRIPTION
Fix unit tests that mixed the expected and actual parameters. This specifically only fixes lines that referenced `Assert.AreEqual`.