### PR TITLE
Selective clears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added the ability to specify a clear for just dialog or just choices
+
+### Changed
+- The `OnClear` event in RumorState has been changed to use a `ClearType` enum,
+  which specifies if everything, just choices, or just dialog was cleared
+
 
 ## [0.2.1] - 2016-11-14
 

--- a/Engine/ClearType.cs
+++ b/Engine/ClearType.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public enum ClearType
+{
+	ALL, CHOICES, DIALOG
+}

--- a/Engine/RumorState.cs
+++ b/Engine/RumorState.cs
@@ -40,7 +40,7 @@ namespace Exodrifter.Rumor.Engine
 		/// <summary>
 		/// An event for when the state is cleared.
 		/// </summary>
-		public event Action OnClear;
+		public event Action<ClearType> OnClear;
 
 		/// <summary>
 		/// Creates a new Rumor state.
@@ -118,7 +118,7 @@ namespace Exodrifter.Rumor.Engine
 			Consequences = new List<List<Node>>();
 
 			if (OnClear != null) {
-				OnClear();
+				OnClear(ClearType.ALL);
 			}
 		}
 
@@ -129,6 +129,22 @@ namespace Exodrifter.Rumor.Engine
 		{
 			Choices = new List<string>();
 			Consequences = new List<List<Node>>();
+
+			if (OnClear != null) {
+				OnClear(ClearType.CHOICES);
+			}
+		}
+
+		/// <summary>
+		/// Clears the dialog.
+		/// </summary>
+		public void ClearDialog()
+		{
+			Dialog = new LazyDictionary<object, string>();
+
+			if (OnClear != null) {
+				OnClear(ClearType.DIALOG);
+			}
 		}
 
 		#region Serialization

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -459,7 +459,20 @@ namespace Exodrifter.Rumor.Lang
 		private Node CompileClear(LogicalLine line, ref int pos, List<Node> children)
 		{
 			ExpectNoChildren(line, children);
-			return new Clear();
+
+			var type = ClearType.ALL;
+
+			SkipWhitespace(line, ref pos);
+			if (pos + 1 < line.tokens.Count) {
+				var arg = Expect(line, pos++);
+				if (arg.ToLower().Equals("choices")) {
+					type = ClearType.CHOICES;
+				} else if (arg.ToLower().Equals("dialog")) {
+					type = ClearType.DIALOG;
+				}
+			}
+
+			return new Clear(type);
 		}
 
 		private Node CompileJump(LogicalLine line, ref int pos, List<Node> children)

--- a/Nodes/Clear.cs
+++ b/Nodes/Clear.cs
@@ -1,4 +1,5 @@
 ﻿using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Util;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -11,14 +12,30 @@ namespace Exodrifter.Rumor.Nodes
 	[Serializable]
 	public sealed class Clear : Node
 	{
+		private ClearType type;
+
 		/// <summary>
 		/// Creates a new Return node.
 		/// </summary>
-		public Clear() { }
+		public Clear(ClearType type)
+		{
+			this.type = type;
+		}
 
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
-			rumor.State.Clear();
+			switch(type)
+			{
+			case ClearType.ALL:
+				rumor.State.Clear();
+				break;
+			case ClearType.CHOICES:
+				rumor.State.ClearChoices();
+				break;
+			case ClearType.DIALOG:
+				rumor.State.ClearDialog();
+				break;
+			}
 			yield return null;
 		}
 
@@ -27,12 +44,14 @@ namespace Exodrifter.Rumor.Nodes
 		public Clear(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
+			type = info.GetValue<ClearType>("type");
 		}
 
 		public override void GetObjectData
 			(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
+			info.AddValue<ClearType>("type", type);
 		}
 
 		#endregion


### PR DESCRIPTION
This will clear the dialog and choices from the state. This is the current behaviour.
```
clear
```

This PR adds the ability to specify what exactly to clear from the state. For example, this will clear just dialog:
```
clear dialog
```

...and this will clear just choices:
```
clear choices
```

The compiler will ignore case, so the following examples would compile as well.
```
clear CHOICES
```
```
clear DiaLOG
```

The ability to selectively clear parts of the state will make it easier to control the flow of the dialog, since it may be desirable to do so. This can be used, for example, to remove old choices before adding replacements during a choose statement or to remove all of the dialog (but not the choices) before calling a pause.