### PR TITLE
Change Pause to wait for advance if seconds <= 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - The `OnClear` event in RumorState has been changed to use a `ClearType` enum,
   which specifies if everything, just choices, or just dialog was cleared
+- The Pause command will now wait for an advance if the time is less than or
+  equal to 0.
 
 
 ## [0.2.1] - 2016-11-14

--- a/Nodes/Pause.cs
+++ b/Nodes/Pause.cs
@@ -43,7 +43,13 @@ namespace Exodrifter.Rumor.Nodes
 		public override IEnumerator<RumorYield> Run(Engine.Rumor rumor)
 		{
 			var value = seconds.Evaluate(rumor) ?? new ObjectValue(null);
-			yield return new ForSeconds(value.AsFloat());
+
+			if (value.AsFloat() > 0) {
+				yield return new ForSeconds(value.AsFloat());
+			}
+			else {
+				yield return new ForAdvance();
+			}
 		}
 
 		#region Serialization


### PR DESCRIPTION
This allows the use of pause to require input from a user instead of just waiting for a specific amount of time.

The reason for adding this feature is that it is possible the user has a script similar to the following:

```
$ move_cube(0, 1, 0)
pause
$ move_cube(1, 0, 0)
```

Before this change, it would be much more difficult to require the user to provide input between commands that don't wait for an advance.