### PR TITLE
Add filter operator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added the default binding `_choice`, which returns the contents of the
   last chosen choice
 - Added the `-=`, `+=`, `/=`, and `*=` assignment operators
+- Filter operator `|` support
 
 ### Changed
 - The `OnClear` event in RumorState has been changed to use a `ClearType` enum,

--- a/Expressions/FilterExpression.cs
+++ b/Expressions/FilterExpression.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Expressions
+{
+	/// <summary>
+	/// Represents a "pipe" or filter operator.
+	/// </summary>
+	[Serializable]
+	public class FilterExpression : OpExpression
+	{
+		public FilterExpression(Expression left, FunctionExpression right)
+			: base(left, right)
+		{
+		}
+
+		public override Value Evaluate(Engine.Rumor rumor)
+		{
+			return ((FunctionExpression)right).Invoke(null, rumor, left);
+		}
+
+		public override string ToString()
+		{
+			return left + " | " + right;
+		}
+
+		#region Serialization
+
+		public FilterExpression
+			(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+
+		#endregion
+	}
+}

--- a/Expressions/FunctionExpression.cs
+++ b/Expressions/FunctionExpression.cs
@@ -37,12 +37,18 @@ namespace Exodrifter.Rumor.Expressions
 			return Invoke(null, rumor);
 		}
 
-		public Value Invoke(object self, Engine.Rumor rumor)
+		public Value Invoke
+			(object self, Engine.Rumor rumor, Expression inject = null)
 		{
-			var values = new object[@params.Count];
+			var p = new List<Expression>(@params);
+			if (inject != null) {
+				p.Insert(0, inject);
+			}
 
-			for (int i = 0; i < @params.Count; ++i) {
-				var value = @params[i].Evaluate(rumor);
+			var values = new object[p.Count];
+
+			for (int i = 0; i < p.Count; ++i) {
+				var value = p[i].Evaluate(rumor);
 
 				if (value == null) {
 					values[i] = null;

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -217,6 +217,7 @@ namespace Exodrifter.Rumor.Lang
 				".", "!",
 				"*", "/", "+", "-",
 				"and", "xor", "or",
+				"|",
 				"==", "!=",
 				"*=", "/=", "+=", "-=",
 				"=",
@@ -292,6 +293,14 @@ namespace Exodrifter.Rumor.Lang
 						return new AddExpression(left, right);
 					case "-":
 						return new SubtractExpression(left, right);
+					case "|":
+						if (right is FunctionExpression)
+						{
+							return new FilterExpression(
+								left, (FunctionExpression)right);
+						}
+						throw new CompilerError(tokens[opIndex],
+							"Filter must have a right hand expression of type function!");
 					case "==":
 						return new EqualsExpression(left, right);
 					case "!=":


### PR DESCRIPTION
Filter operator support has been added as defined in #23. The pipe operator can be used anywhere an expression can be used as it is treated like another operator

While writing this implementation, it occurred to me that the filter syntax is weird and possibly confusing. Consider that the filter operator still makes a method call, but it does so by injecting a parameter in front of the others. For example:

```
seconds | format("YYYY-MM-dd")
```

...is the same as...

```
format(seconds, "YYYY-MM-dd")
```

On one hand, I enjoy the first sample better, since it places more emphasis on the variable, which is what I care about reading. On the other hand, methods no longer have the "correct" number of parameters inside of them.

Additionally, what should I do in this scenario?

```
rumor.Bind("foo", () => { Debug.Log("Hello world"); });
```
```
4 | foo()
```
Since the method foo takes no parameters, what should the filter operator do? Should it call foo without the parameter? Should it throw an error?

To me, the pros and cons here equalize each other out. I'll leave this up as a pull request until someone can write a compelling reason to either include or exclude this feature or until someone can propose/implement a change that makes this feature more worthwhile.