### PR TITLE
Comparison Operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added the default binding `_choice`, which returns the contents of the
   last chosen choice
 - Added the `-=`, `+=`, `/=`, and `*=` assignment operators
+- Added the `<`, `<=`, `>`, and `>=` comparison operators
 
 ### Changed
 - The `OnClear` event in RumorState has been changed to use a `ClearType` enum,

--- a/Editor/Tests/Expressions/ValueTest.cs
+++ b/Editor/Tests/Expressions/ValueTest.cs
@@ -264,6 +264,112 @@ namespace Exodrifter.Rumor.Test.Expressions
 		}
 
 		/// <summary>
+		/// Check Less Than.
+		/// </summary>
+		[Test]
+		public void ValueLessThan()
+		{
+			var @int = new IntValue(1);
+			var @int2 = new IntValue(2);
+			var @float = new FloatValue(1.0f);
+			var @float2 = new FloatValue(2.0f);
+			var @string = new StringValue("1");
+			var @bool = new BoolValue(false);
+			var @obj = new ObjectValue(new Foo());
+
+			Assert.AreEqual(false, @int.LessThan(@int).AsBool());
+			Assert.AreEqual(false, @int.LessThan(@float).AsBool());
+			Assert.AreEqual(true, @int.LessThan(@int2).AsBool());
+			Assert.AreEqual(true, @int.LessThan(@float2).AsBool());
+			Assert.AreEqual(false, @int2.LessThan(@int).AsBool());
+			Assert.AreEqual(false, @int2.LessThan(@float).AsBool());
+			Assert.Catch<InvalidOperationException>(() => @int.LessThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @int.LessThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @int.LessThan(@obj));
+
+			Assert.AreEqual(false, @float.LessThan(@int).AsBool());
+			Assert.AreEqual(false, @float.LessThan(@float).AsBool());
+			Assert.AreEqual(true, @float.LessThan(@int2).AsBool());
+			Assert.AreEqual(true, @float.LessThan(@float2).AsBool());
+			Assert.AreEqual(false, @float2.LessThan(@int).AsBool());
+			Assert.AreEqual(false, @float2.LessThan(@float).AsBool());
+			Assert.Catch<InvalidOperationException>(() => @float.LessThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @float.LessThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @float.LessThan(@obj));
+
+			Assert.Catch<InvalidOperationException>(() => @string.LessThan(@int));
+			Assert.Catch<InvalidOperationException>(() => @string.LessThan(@float));
+			Assert.Catch<InvalidOperationException>(() => @string.LessThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @string.LessThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @string.LessThan(@obj));
+
+			Assert.Catch<InvalidOperationException>(() => @bool.LessThan(@int));
+			Assert.Catch<InvalidOperationException>(() => @bool.LessThan(@float));
+			Assert.Catch<InvalidOperationException>(() => @bool.LessThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @bool.LessThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @bool.LessThan(@obj));
+
+			Assert.Catch<InvalidOperationException>(() => @obj.LessThan(@int));
+			Assert.Catch<InvalidOperationException>(() => @obj.LessThan(@float));
+			Assert.Catch<InvalidOperationException>(() => @obj.LessThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @obj.LessThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @obj.LessThan(@obj));
+		}
+
+		/// <summary>
+		/// Check Less Than.
+		/// </summary>
+		[Test]
+		public void ValueGreaterThan()
+		{
+			var @int = new IntValue(1);
+			var @int2 = new IntValue(2);
+			var @float = new FloatValue(1.0f);
+			var @float2 = new FloatValue(2.0f);
+			var @string = new StringValue("1");
+			var @bool = new BoolValue(false);
+			var @obj = new ObjectValue(new Foo());
+
+			Assert.AreEqual(false, @int.GreaterThan(@int).AsBool());
+			Assert.AreEqual(false, @int.GreaterThan(@float).AsBool());
+			Assert.AreEqual(false, @int.GreaterThan(@int2).AsBool());
+			Assert.AreEqual(false, @int.GreaterThan(@float2).AsBool());
+			Assert.AreEqual(true, @int2.GreaterThan(@int).AsBool());
+			Assert.AreEqual(true, @int2.GreaterThan(@float).AsBool());
+			Assert.Catch<InvalidOperationException>(() => @int.GreaterThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @int.GreaterThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @int.GreaterThan(@obj));
+
+			Assert.AreEqual(false, @float.GreaterThan(@int).AsBool());
+			Assert.AreEqual(false, @float.GreaterThan(@float).AsBool());
+			Assert.AreEqual(false, @float.GreaterThan(@int2).AsBool());
+			Assert.AreEqual(false, @float.GreaterThan(@float2).AsBool());
+			Assert.AreEqual(true, @float2.GreaterThan(@int).AsBool());
+			Assert.AreEqual(true, @float2.GreaterThan(@float).AsBool());
+			Assert.Catch<InvalidOperationException>(() => @float.GreaterThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @float.GreaterThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @float.GreaterThan(@obj));
+
+			Assert.Catch<InvalidOperationException>(() => @string.GreaterThan(@int));
+			Assert.Catch<InvalidOperationException>(() => @string.GreaterThan(@float));
+			Assert.Catch<InvalidOperationException>(() => @string.GreaterThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @string.GreaterThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @string.GreaterThan(@obj));
+
+			Assert.Catch<InvalidOperationException>(() => @bool.GreaterThan(@int));
+			Assert.Catch<InvalidOperationException>(() => @bool.GreaterThan(@float));
+			Assert.Catch<InvalidOperationException>(() => @bool.GreaterThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @bool.GreaterThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @bool.GreaterThan(@obj));
+
+			Assert.Catch<InvalidOperationException>(() => @obj.GreaterThan(@int));
+			Assert.Catch<InvalidOperationException>(() => @obj.GreaterThan(@float));
+			Assert.Catch<InvalidOperationException>(() => @obj.GreaterThan(@string));
+			Assert.Catch<InvalidOperationException>(() => @obj.GreaterThan(@bool));
+			Assert.Catch<InvalidOperationException>(() => @obj.GreaterThan(@obj));
+		}
+
+		/// <summary>
 		/// Check Boolean And.
 		/// </summary>
 		[Test]

--- a/Expressions/GreaterThanExpression.cs
+++ b/Expressions/GreaterThanExpression.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Expressions
+{
+	/// <summary>
+	/// Represents an less than operator that is used to compare two arguments.
+	/// </summary>
+	[Serializable]
+	public class GreaterThanExpression : OpExpression
+	{
+		public GreaterThanExpression(Expression left, Expression right)
+			: base(left, right)
+		{
+		}
+
+		public override Value Evaluate(Engine.Rumor rumor)
+		{
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
+			return l.GreaterThan(r);
+		}
+
+		public override string ToString()
+		{
+			return left + ">" + right;
+		}
+
+		#region Serialization
+
+		public GreaterThanExpression
+			(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+
+		#endregion
+	}
+}

--- a/Expressions/GreaterThanOrEqualExpression.cs
+++ b/Expressions/GreaterThanOrEqualExpression.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Expressions
+{
+	/// <summary>
+	/// Represents an less than operator that is used to compare two arguments.
+	/// </summary>
+	[Serializable]
+	public class GreaterThanOrEqualExpression : OpExpression
+	{
+		public GreaterThanOrEqualExpression(Expression left, Expression right)
+			: base(left, right)
+		{
+		}
+
+		public override Value Evaluate(Engine.Rumor rumor)
+		{
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
+			return new BoolValue(l.GreaterThan(r).AsBool() || l.Equals(r));
+		}
+
+		public override string ToString()
+		{
+			return left + ">=" + right;
+		}
+
+		#region Serialization
+
+		public GreaterThanOrEqualExpression
+			(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+
+		#endregion
+	}
+}

--- a/Expressions/LessThanExpression.cs
+++ b/Expressions/LessThanExpression.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Expressions
+{
+	/// <summary>
+	/// Represents an less than operator that is used to compare two arguments.
+	/// </summary>
+	[Serializable]
+	public class LessThanExpression : OpExpression
+	{
+		public LessThanExpression(Expression left, Expression right)
+			: base(left, right)
+		{
+		}
+
+		public override Value Evaluate(Engine.Rumor rumor)
+		{
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
+			return l.LessThan(r);
+		}
+
+		public override string ToString()
+		{
+			return left + "<" + right;
+		}
+
+		#region Serialization
+
+		public LessThanExpression
+			(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+
+		#endregion
+	}
+}

--- a/Expressions/LessThanOrEqualExpression.cs
+++ b/Expressions/LessThanOrEqualExpression.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Exodrifter.Rumor.Expressions
+{
+	/// <summary>
+	/// Represents an less than operator that is used to compare two arguments.
+	/// </summary>
+	[Serializable]
+	public class LessThanOrEqualExpression : OpExpression
+	{
+		public LessThanOrEqualExpression(Expression left, Expression right)
+			: base(left, right)
+		{
+		}
+
+		public override Value Evaluate(Engine.Rumor rumor)
+		{
+			var l = left.Evaluate(rumor) ?? new ObjectValue(null);
+			var r = right.Evaluate(rumor) ?? new ObjectValue(null);
+			return new BoolValue(l.LessThan(r).AsBool() || l.Equals(r));
+		}
+
+		public override string ToString()
+		{
+			return left + "<=" + right;
+		}
+
+		#region Serialization
+
+		public LessThanOrEqualExpression
+			(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+
+		#endregion
+	}
+}

--- a/Expressions/Value/BoolValue.cs
+++ b/Expressions/Value/BoolValue.cs
@@ -38,6 +38,16 @@ namespace Exodrifter.Rumor.Expressions
 			throw new InvalidOperationException();
 		}
 
+		public override Value LessThan(Value value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		public override Value GreaterThan(Value value)
+		{
+			throw new InvalidOperationException();
+		}
+
 		public override Value Divide(Value value)
 		{
 			throw new InvalidOperationException();

--- a/Expressions/Value/FloatValue.cs
+++ b/Expressions/Value/FloatValue.cs
@@ -87,6 +87,34 @@ namespace Exodrifter.Rumor.Expressions
 			throw new InvalidOperationException();
 		}
 
+		public override Value LessThan(Value value)
+		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
+			if (value.IsInt()) {
+				return new BoolValue(AsFloat() < value.AsInt());
+			}
+			if (value.IsFloat()) {
+				return new BoolValue(AsFloat() < value.AsFloat());
+			}
+			throw new InvalidOperationException();
+		}
+
+		public override Value GreaterThan(Value value)
+		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
+			if (value.IsInt()) {
+				return new BoolValue(AsFloat() > value.AsInt());
+			}
+			if (value.IsFloat()) {
+				return new BoolValue(AsFloat() > value.AsFloat());
+			}
+			throw new InvalidOperationException();
+		}
+
 		public override Value BoolAnd(Value value)
 		{
 			if (value == null) {

--- a/Expressions/Value/IntValue.cs
+++ b/Expressions/Value/IntValue.cs
@@ -87,6 +87,34 @@ namespace Exodrifter.Rumor.Expressions
 			throw new InvalidOperationException();
 		}
 
+		public override Value LessThan(Value value)
+		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
+			if (value.IsInt()) {
+				return new BoolValue(AsInt() < value.AsInt());
+			}
+			if (value.IsFloat()) {
+				return new BoolValue(AsInt() < value.AsFloat());
+			}
+			throw new InvalidOperationException();
+		}
+
+		public override Value GreaterThan(Value value)
+		{
+			if (value == null) {
+				throw new InvalidOperationException();
+			}
+			if (value.IsInt()) {
+				return new BoolValue(AsInt() > value.AsInt());
+			}
+			if (value.IsFloat()) {
+				return new BoolValue(AsInt() > value.AsFloat());
+			}
+			throw new InvalidOperationException();
+		}
+
 		public override Value BoolAnd(Value value)
 		{
 			if (value == null) {

--- a/Expressions/Value/ObjectValue.cs
+++ b/Expressions/Value/ObjectValue.cs
@@ -98,6 +98,16 @@ namespace Exodrifter.Rumor.Expressions
 			throw new InvalidOperationException();
 		}
 
+		public override Value LessThan(Value value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		public override Value GreaterThan(Value value)
+		{
+			throw new InvalidOperationException();
+		}
+
 		public override Value BoolAnd(Value value)
 		{
 			if (AsObject() == null) {

--- a/Expressions/Value/StringValue.cs
+++ b/Expressions/Value/StringValue.cs
@@ -55,6 +55,16 @@ namespace Exodrifter.Rumor.Expressions
 			throw new InvalidOperationException();
 		}
 
+		public override Value LessThan(Value value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		public override Value GreaterThan(Value value)
+		{
+			throw new InvalidOperationException();
+		}
+
 		public override Value BoolAnd(Value value)
 		{
 			if (value == null) {

--- a/Expressions/Value/Value.cs
+++ b/Expressions/Value/Value.cs
@@ -185,6 +185,9 @@ namespace Exodrifter.Rumor.Expressions
 		public abstract Value Multiply(Value value);
 		public abstract Value Divide(Value value);
 
+		public abstract Value LessThan(Value value);
+		public abstract Value GreaterThan(Value value);
+
 		public abstract Value BoolAnd(Value value);
 		public abstract Value BoolOr(Value value);
 		public Value BoolXor(Value value)

--- a/Lang/RumorCompiler.cs
+++ b/Lang/RumorCompiler.cs
@@ -216,6 +216,7 @@ namespace Exodrifter.Rumor.Lang
 			var ops = new List<string>() {
 				".", "!",
 				"*", "/", "+", "-",
+				"<", ">", "<=", ">=",
 				"and", "xor", "or",
 				"==", "!=",
 				"*=", "/=", "+=", "-=",
@@ -296,6 +297,14 @@ namespace Exodrifter.Rumor.Lang
 						return new EqualsExpression(left, right);
 					case "!=":
 						return new NotEqualsExpression(left, right);
+					case "<":
+						return new LessThanExpression(left, right);
+					case ">":
+						return new GreaterThanExpression(left, right);
+					case "<=":
+						return new LessThanOrEqualExpression(left, right);
+					case ">=":
+						return new GreaterThanOrEqualExpression(left, right);
 					case "and":
 						return new BoolAndExpression(left, right);
 					case "xor":


### PR DESCRIPTION
Added the comparison operators `<`, `<=`, `>`, and `>=`.

The operators can be used with `int` and `float` types. Attempting to use these operators with `bool`, `string`, and `object` types will throw an `InvalidOperationException`.