### PR TITLE
Fixes #36 Make `Rumor.CallBinding` faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Rumor no longer clears the scope when starting
+- `Rumor.CallBinding` no longer calls DynamicInvoke and is much faster
 
 ### Fixed
 - Fix `Rumor.Choosing` throwing an error if Rumor has not been started

--- a/Engine/Rumor.cs
+++ b/Engine/Rumor.cs
@@ -550,7 +550,7 @@ namespace Exodrifter.Rumor.Engine
 		/// <summary>
 		/// Stores functions, methods, or constructors.
 		/// </summary>
-		private Dictionary<string, object> bindings;
+		private Dictionary<string, RumorBinding> bindings;
 
 		/// <summary>
 		/// Bind a <see cref="Action"/> to the Rumor metatable so it can be
@@ -560,7 +560,7 @@ namespace Exodrifter.Rumor.Engine
 		/// <param name="action">The action to bind.</param>
 		public void Bind(string name, Action action)
 		{
-			AddBinding(name, 0, action);
+			AddBinding(name, 0, new BindingAction(action));
 		}
 
 		/// <summary>
@@ -571,7 +571,7 @@ namespace Exodrifter.Rumor.Engine
 		/// <param name="action">The <see cref="Action{T}"/> to bind.</param>
 		public void Bind<T1>(string name, Action<T1> action)
 		{
-			AddBinding(name, 1, action);
+			AddBinding(name, 1, new BindingAction<T1>(action));
 		}
 
 		/// <summary>
@@ -584,7 +584,7 @@ namespace Exodrifter.Rumor.Engine
 		/// </param>
 		public void Bind<T1, T2>(string name, Action<T1, T2> action)
 		{
-			AddBinding(name, 2, action);
+			AddBinding(name, 2, new BindingAction<T1, T2>(action));
 		}
 
 		/// <summary>
@@ -598,7 +598,7 @@ namespace Exodrifter.Rumor.Engine
 		public void Bind<T1, T2, T3>
 			(string name, Action<T1, T2, T3> action)
 		{
-			AddBinding(name, 3, action);
+			AddBinding(name, 3, new BindingAction<T1, T2, T3>(action));
 		}
 
 		/// <summary>
@@ -612,7 +612,7 @@ namespace Exodrifter.Rumor.Engine
 		public void Bind<T1, T2, T3, T4>
 			(string name, Action<T1, T2, T3, T4> action)
 		{
-			AddBinding(name, 4, action);
+			AddBinding(name, 4, new BindingAction<T1, T2, T3, T4>(action));
 		}
 
 		/// <summary>
@@ -625,7 +625,7 @@ namespace Exodrifter.Rumor.Engine
 		/// </param>
 		public void Bind<TResult>(string name, Func<TResult> func)
 		{
-			AddBinding(name, 0, func);
+			AddBinding(name, 0, new BindingFunc<TResult>(func));
 		}
 
 		/// <summary>
@@ -638,7 +638,7 @@ namespace Exodrifter.Rumor.Engine
 		/// </param>
 		public void Bind<T1, TResult>(string name, Func<T1, TResult> func)
 		{
-			AddBinding(name, 1, func);
+			AddBinding(name, 1, new BindingFunc<T1, TResult>(func));
 		}
 
 		/// <summary>
@@ -652,7 +652,7 @@ namespace Exodrifter.Rumor.Engine
 		public void Bind<T1, T2, TResult>
 			(string name, Func<T1, T2, TResult> func)
 		{
-			AddBinding(name, 2, func);
+			AddBinding(name, 2, new BindingFunc<T1, T2, TResult>(func));
 		}
 
 		/// <summary>
@@ -666,7 +666,7 @@ namespace Exodrifter.Rumor.Engine
 		public void Bind<T1, T2, T3, TResult>
 			(string name, Func<T1, T2, T3, TResult> func)
 		{
-			AddBinding(name, 3, func);
+			AddBinding(name, 3, new BindingFunc<T1, T2, T3, TResult>(func));
 		}
 
 		/// <summary>
@@ -680,7 +680,7 @@ namespace Exodrifter.Rumor.Engine
 		public void Bind<T1, T2, T3, T4, TResult>
 			(string name, Func<T1, T2, T3, T4, TResult> func)
 		{
-			AddBinding(name, 4, func);
+			AddBinding(name, 4, new BindingFunc<T1, T2, T3, T4, TResult>(func));
 		}
 
 		/// <summary>
@@ -691,13 +691,13 @@ namespace Exodrifter.Rumor.Engine
 		/// The number of parameters in the binding.
 		/// </param>
 		/// <param name="binding">The binding to use.</param>
-		private void AddBinding(string name, int paramCount, object binding)
+		private void AddBinding(string name, int paramCount, RumorBinding binding)
 		{
 			if (binding == null) {
 				throw new ArgumentNullException();
 			}
 
-			bindings = bindings ?? new Dictionary<string, object>();
+			bindings = bindings ?? new Dictionary<string, RumorBinding>();
 
 			var mungedName = MungeName(name, paramCount);
 			if (bindings.ContainsKey(mungedName))
@@ -720,7 +720,7 @@ namespace Exodrifter.Rumor.Engine
 		/// <returns>The result of calling the binding.</returns>
 		public object CallBinding(string name, params object[] p)
 		{
-			bindings = bindings ?? new Dictionary<string, object>();
+			bindings = bindings ?? new Dictionary<string, RumorBinding>();
 
 			var mungedName = MungeName(name, p.Length);
 			if (!bindings.ContainsKey(mungedName))
@@ -732,7 +732,7 @@ namespace Exodrifter.Rumor.Engine
 					name, p.Length, paramStr));
 			}
 
-			return ((Delegate)bindings[mungedName]).DynamicInvoke(p);
+			return bindings[mungedName].Invoke(p);
 		}
 
 		/// <summary>

--- a/Engine/RumorBinding.cs
+++ b/Engine/RumorBinding.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Exodrifter.Rumor.Engine
+{
+	public abstract class RumorBinding
+	{
+		public abstract object Invoke(object[] args);
+	}
+
+	public class BindingAction : RumorBinding
+	{
+		private Action action;
+
+		public BindingAction(Action action)
+		{
+			this.action = action;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			action();
+			return null;
+		}
+	}
+
+	public class BindingAction<T1> : RumorBinding
+	{
+		private Action<T1> action;
+
+		public BindingAction(Action<T1> action)
+		{
+			this.action = action;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			Convert()(args[0]);
+			return null;
+		}
+
+		private Action<object> Convert()
+		{
+			return new Action<object>(
+				(a) => { action((T1)a); }
+			);
+		}
+	}
+
+	public class BindingAction<T1, T2> : RumorBinding
+	{
+		private Action<T1, T2> action;
+
+		public BindingAction(Action<T1, T2> action)
+		{
+			this.action = action;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			Convert()(args[0], args[1]);
+			return null;
+		}
+
+		private Action<object, object> Convert()
+		{
+			return new Action<object, object>(
+				(a, b) => { action((T1)a, (T2)b); }
+			);
+		}
+	}
+
+	public class BindingAction<T1, T2, T3> : RumorBinding
+	{
+		private Action<T1, T2, T3> action;
+
+		public BindingAction(Action<T1, T2, T3> action)
+		{
+			this.action = action;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			Convert()(args[0], args[1], args[2]);
+			return null;
+		}
+
+		private Action<object, object, object> Convert()
+		{
+			return new Action<object, object, object>(
+				(a, b, c) => { action((T1)a, (T2)b, (T3)c); }
+			);
+		}
+	}
+
+	public class BindingAction<T1, T2, T3, T4> : RumorBinding
+	{
+		private Action<T1, T2, T3, T4> action;
+
+		public BindingAction(Action<T1, T2, T3, T4> action)
+		{
+			this.action = action;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			Convert()(args[0], args[1], args[2], args[3]);
+			return null;
+		}
+
+		private Action<object, object, object, object> Convert()
+		{
+			return new Action<object, object, object, object>(
+				(a, b, c, d) => { action((T1)a, (T2)b, (T3)c, (T4)d); }
+			);
+		}
+	}
+
+	public class BindingFunc<TResult> : RumorBinding
+	{
+		private Func<TResult> func;
+
+		public BindingFunc(Func<TResult> func)
+		{
+			this.func = func;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			return func();
+		}
+	}
+
+	public class BindingFunc<T1, TResult> : RumorBinding
+	{
+		private Func<T1, TResult> func;
+
+		public BindingFunc(Func<T1, TResult> func)
+		{
+			this.func = func;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			return Convert()(args[0]);
+		}
+
+		private Func<object, object> Convert()
+		{
+			return new Func<object, object>(
+				(a) => { return func((T1)a); }
+			);
+		}
+	}
+
+	public class BindingFunc<T1, T2, TResult> : RumorBinding
+	{
+		private Func<T1, T2, TResult> func;
+
+		public BindingFunc(Func<T1, T2, TResult> func)
+		{
+			this.func = func;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			return Convert()(args[0], args[1]);
+		}
+
+		private Func<object, object, object> Convert()
+		{
+			return new Func<object, object, object>(
+				(a, b) => { return func((T1)a, (T2)b); }
+			);
+		}
+	}
+
+	public class BindingFunc<T1, T2, T3, TResult> : RumorBinding
+	{
+		private Func<T1, T2, T3, TResult> func;
+
+		public BindingFunc(Func<T1, T2, T3, TResult> func)
+		{
+			this.func = func;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			return Convert()(args[0], args[1], args[2]);
+		}
+
+		private Func<object, object, object, object> Convert()
+		{
+			return new Func<object, object, object, object>(
+				(a, b, c) => { return func((T1)a, (T2)b, (T3)c); }
+			);
+		}
+	}
+
+	public class BindingFunc<T1, T2, T3, T4, TResult> : RumorBinding
+	{
+		private Func<T1, T2, T3, T4, TResult> func;
+
+		public BindingFunc(Func<T1, T2, T3, T4, TResult> func)
+		{
+			this.func = func;
+		}
+
+		public override object Invoke(object[] args)
+		{
+			return Convert()(args[0], args[1], args[2], args[3]);
+		}
+
+		private Func<object, object, object, object, object> Convert()
+		{
+			return new Func<object, object, object, object, object>(
+				(a, b, c, d) => { return func((T1)a, (T2)b, (T3)c, (T4)d); }
+			);
+		}
+	}
+}


### PR DESCRIPTION
`Rumor.CallBinding` no longer calls `DynamicInvoke`, which is very expensive. Instead, all `Action` and `Func` delegates are wrapped in a class called `RumorBinding`. This wrapper class then calls `Invoke` for us, which is much faster than `DynamicInvoke`