### PR TITLE
Fixes #38 Tokenizer Optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Rumor.CallBinding` no longer calls DynamicInvoke and is much faster
 - Null ObjectValues are now treated the same as an uninitialized (null)
   variable
+- Tokenize step of compilation is much faster
 
 ### Fixed
 - Fix `Rumor.Choosing` throwing an error if Rumor has not been started

--- a/Editor/Tests/Lang/CompilerTest.cs
+++ b/Editor/Tests/Lang/CompilerTest.cs
@@ -55,31 +55,25 @@ namespace Exodrifter.Rumor.Test.Lang
 		[Test]
 		public void PauseAcceptsFloat()
 		{
+			var rumor = new Rumor.Engine.Rumor("return");
+
 			var str = "pause 0";
 			var nodes = new List<Node>(new RumorCompiler().Compile(str));
-
-			var rumor = new Rumor.Engine.Rumor("return");
 			Assert.AreEqual(1, nodes.Count);
 			Assert.AreEqual(0f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause .5";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
-			
-			rumor = new Rumor.Engine.Rumor("return");
 			Assert.AreEqual(1, nodes.Count);
 			Assert.AreEqual(0.5f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause 0.5";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
-
-			rumor = new Rumor.Engine.Rumor("return");
 			Assert.AreEqual(1, nodes.Count);
 			Assert.AreEqual(0.5f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 
 			str = "pause 1";
 			nodes = new List<Node>(new RumorCompiler().Compile(str));
-
-			rumor = new Rumor.Engine.Rumor("return");
 			Assert.AreEqual(1, nodes.Count);
 			Assert.AreEqual(1f, (nodes[0] as Pause).seconds.Evaluate(rumor).AsFloat());
 		}

--- a/Editor/Tests/Lang/TokenizerTest.cs
+++ b/Editor/Tests/Lang/TokenizerTest.cs
@@ -17,7 +17,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				"\n", " ", " ", " ", " ",
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = " \r\n   ";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -42,7 +42,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				"\r\n", "\n", "\r", "\t", " ",
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = " \r\n\r\t";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -65,7 +65,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				" ", "\t", "\r", "\n", "\r\n",
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = " \r\n\r\t";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -88,7 +88,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				" ",
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = "    ";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -111,7 +111,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				" ", "  "
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = "     ";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -132,7 +132,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				" ",
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = "Hello, world!";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -154,7 +154,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				" ", ",", "!"
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = "Hello, world!";
 			var tokens = new List<string>(tokenizer.Tokenize(input));
@@ -178,7 +178,7 @@ namespace Exodrifter.Rumor.Test.Lang
 			{
 				" ", "->", "float"
 			};
-			var tokenizer = new Tokenizer(keywords, new List<string>());
+			var tokenizer = new Tokenizer(keywords);
 
 			var input = "float a -> float b";
 			var tokens = new List<string>(tokenizer.Tokenize(input));

--- a/Lang/Tokenizer.cs
+++ b/Lang/Tokenizer.cs
@@ -19,6 +19,7 @@ namespace Exodrifter.Rumor.Lang
 		/// </summary>
 		List<string> keywords;
 		HashSet<string> keywordsHashset;
+		int longestKeywordLength;
 
 		/// <summary>
 		/// Creates a new tokenizer. Any sequence of characters that is not
@@ -30,6 +31,15 @@ namespace Exodrifter.Rumor.Lang
 		{
 			this.keywords = new List<string>(keywords.OrderByDescending(w => w.Length));
 			keywordsHashset = new HashSet<string>(keywords);
+
+			longestKeywordLength = 0;
+			foreach (var keyword in keywords)
+			{
+				if (keyword.Length > longestKeywordLength)
+				{
+					longestKeywordLength = keyword.Length;
+				}
+			}
 		}
 
 		/// <summary>
@@ -39,11 +49,12 @@ namespace Exodrifter.Rumor.Lang
 		/// <returns>The tokens.</returns>
 		public IEnumerable<string> Tokenize(string input)
 		{
-			var tokenBuffer = new List<string>() { input };
+			var tokenBuffer = new LinkedList<string>();
+			tokenBuffer.AddLast(input);
 
 			foreach (var keyword in keywords) {
 
-				var currentBuffer = new List<string>();
+				var currentBuffer = new LinkedList<string>();
 				var separator = new string[] { keyword };
 				var splitOption = StringSplitOptions.None;
 
@@ -51,8 +62,8 @@ namespace Exodrifter.Rumor.Lang
 				foreach (var token in tokenBuffer) {
 
 					// If the item is a keyword, ignore it
-					if (keywordsHashset.Contains(token)) {
-						currentBuffer.Add(token);
+					if (token.Length <= longestKeywordLength && keywordsHashset.Contains(token)) {
+						currentBuffer.AddLast(token);
 						continue;
 					}
 
@@ -60,11 +71,11 @@ namespace Exodrifter.Rumor.Lang
 					string[] parts = token.Split(separator, splitOption);
 					foreach (var part in parts) {
 						if (part != "") {
-							currentBuffer.Add(part);
+							currentBuffer.AddLast(part);
 						}
-						currentBuffer.Add(keyword);
+						currentBuffer.AddLast(keyword);
 					}
-					currentBuffer.RemoveAt(currentBuffer.Count - 1);
+					currentBuffer.RemoveLast();
 				}
 
 				// Update the token buffer

--- a/Lang/Tokenizer.cs
+++ b/Lang/Tokenizer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Exodrifter.Rumor.Lang
 {
@@ -18,12 +17,8 @@ namespace Exodrifter.Rumor.Lang
 		/// <summary>
 		/// The keywords to treat as tokens.
 		/// </summary>
-		IEnumerable<string> keywords;
-
-		/// <summary>
-		/// The regex matches to treat as tokens.
-		/// </summary>
-		IEnumerable<string> regex;
+		List<string> keywords;
+		HashSet<string> keywordsHashset;
 
 		/// <summary>
 		/// Creates a new tokenizer. Any sequence of characters that is not
@@ -31,10 +26,10 @@ namespace Exodrifter.Rumor.Lang
 		/// </summary>
 		/// <param name="keywords">The keywords to treat as tokens.</param>
 		/// <param name="regex">The regex matches to treat as tokens.</param>
-		public Tokenizer(IEnumerable<string> keywords, IEnumerable<string> regex)
+		public Tokenizer(IEnumerable<string> keywords)
 		{
-			this.keywords = keywords.OrderByDescending(w => w.Length);
-			this.regex = regex;
+			this.keywords = new List<string>(keywords.OrderByDescending(w => w.Length));
+			keywordsHashset = new HashSet<string>(keywords);
 		}
 
 		/// <summary>
@@ -46,22 +41,6 @@ namespace Exodrifter.Rumor.Lang
 		{
 			var tokenBuffer = new List<string>() { input };
 
-			// Tokenize based on regex
-			foreach (var r in regex) {
-
-				var currentBuffer = new List<string>();
-				var reg = new Regex(r);
-
-				// Try to split each item in our token buffer
-				foreach (var token in tokenBuffer) {
-					currentBuffer.AddRange(reg.Split(token));
-				}
-
-				// Update the token buffer
-				tokenBuffer = currentBuffer;
-			}
-
-			// Tokenize based on keywords
 			foreach (var keyword in keywords) {
 
 				var currentBuffer = new List<string>();
@@ -72,21 +51,8 @@ namespace Exodrifter.Rumor.Lang
 				foreach (var token in tokenBuffer) {
 
 					// If the item is a keyword, ignore it
-					if (keywords.Contains(token)) {
+					if (keywordsHashset.Contains(token)) {
 						currentBuffer.Add(token);
-						continue;
-					}
-
-					// If the item is a regex match, ignore it
-					bool regexMatched = false;
-					foreach (var r in regex) {
-						if (new Regex(r).IsMatch(token)) {
-							currentBuffer.Add(token);
-							regexMatched = true;
-							break;
-						}
-					}
-					if (regexMatched) {
 						continue;
 					}
 


### PR DESCRIPTION
`Tokenizer` previously benchmarked around 6600ms on my development machine. This commit improves the performance of the `Tokenizer`, and hence the compilation of Rumor, to about 220ms. This is a 30x speed increase.

This performance boost was achieved by discarding the use of regex and stitching floats back together again after the tokenize step is done.

Additionally, some minor changes where made to `Tokenizer` for some minor performance benefit.