### PR TITLE
Fix Tokenizer failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix unit test failures caused by Tokenize performance optimization code
+
 ## [1.0.1] - 2017-12-19
 
 ### Changed

--- a/Lang/Tokenizer.cs
+++ b/Lang/Tokenizer.cs
@@ -72,7 +72,7 @@ namespace Exodrifter.Rumor.Lang
 				// Add the token
 				if (foundToken)
 				{
-					// Add string before this token
+					// Add non-token string before this token
 					if (!string.IsNullOrEmpty(current))
 					{
 						tokenBuffer.Add(current);
@@ -82,7 +82,7 @@ namespace Exodrifter.Rumor.Lang
 					tokenBuffer.Add(token);
 					pos += token.Length;
 				}
-				// This character is not part of a token
+				// This character is not part of a non-token string
 				else
 				{
 					current += input[pos];
@@ -90,6 +90,7 @@ namespace Exodrifter.Rumor.Lang
 				}
 			}
 
+			// Add remaining non-token string
 			if (!string.IsNullOrEmpty(current))
 			{
 				tokenBuffer.Add(current);

--- a/Lang/Tokenizer.cs
+++ b/Lang/Tokenizer.cs
@@ -48,45 +48,52 @@ namespace Exodrifter.Rumor.Lang
 			var tokenBuffer = new List<string>();
 
 			string current = "";
-			int length = 1;
-			for (int pos = 1; pos <= input.Length; ++pos)
+			for (int pos = 0; pos < input.Length;)
 			{
 				bool foundToken = false;
-				for (int l = length; l > 0; --l)
+
+				// Find the longest token starting at this position
+				string token = null;
+				for (int len = longestKeywordLength; len >= 0; --len)
 				{
-					var token = input.Substring(pos - l, l);
+					if (pos + len > input.Length)
+					{
+						continue;
+					}
+
+					token = input.Substring(pos, len);
 					if (keywordsHashset.Contains(token))
 					{
-						var pre = current + input.Substring(pos - length, length - l);
-						if (!string.IsNullOrEmpty(pre))
-						{
-							tokenBuffer.Add(pre);
-						}
-
-						tokenBuffer.Add(token);
-						current = "";
 						foundToken = true;
 						break;
 					}
 				}
 
+				// Add the token
 				if (foundToken)
 				{
-					length = 1;
+					// Add string before this token
+					if (!string.IsNullOrEmpty(current))
+					{
+						tokenBuffer.Add(current);
+						current = "";
+					}
+
+					tokenBuffer.Add(token);
+					pos += token.Length;
 				}
+				// This character is not part of a token
 				else
 				{
-					if (length == longestKeywordLength)
-					{
-						current += input[pos - longestKeywordLength];
-					}
-					else
-					{
-						length++;
-					}
+					current += input[pos];
+					pos++;
 				}
 			}
 
+			if (!string.IsNullOrEmpty(current))
+			{
+				tokenBuffer.Add(current);
+			}
 			return tokenBuffer;
 		}
 	}


### PR DESCRIPTION
Many unit tests were failing due to `Tokenizer.Tokenize` failing to tokenize strings correctly. This PR introduces a simpler and more robust tokenize algorithm.