### PR TITLE
More comprehensive expression test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix compilation error when comment directly follows a statement expecting a
   block
 * Fix pauses not ending if a choice has been picked
+* Fix `==` expressions almost always returning `true` instead of the correct
+  value
+* Fix `.` expressions with `null` on the left side causing an error instead of
+  returning null
+* Update test that said using the `.` operator on primitives shouldn't work when
+  it actually does
+* Fix not all cases throw a `DivideByZero` exception when dividing by `0` or
+  `null` when they should throw that exception every time
+* Fix `null + null` to return `null` instead of throwing
+  `InvalidOperationException`
 
 ## [2.0.1] - 2018-04-15
 

--- a/Editor/Tests/Expressions/BoolExpressionTest.cs
+++ b/Editor/Tests/Expressions/BoolExpressionTest.cs
@@ -1,0 +1,303 @@
+﻿#if UNITY_EDITOR
+
+using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
+using NUnit.Framework;
+using System;
+
+/// <summary>
+/// Tests expressions with boolean and null as the left and right arguments.
+/// </summary>
+namespace Exodrifter.Rumor.Test.Expressions
+{
+	public class BoolExpressionTest
+	{
+		private readonly VariableExpression varA = new VariableExpression("a");
+		private readonly VariableExpression varB = new VariableExpression("b");
+		private readonly VariableExpression varNull = new VariableExpression("null");
+		private readonly Scope scope = new Scope();
+		private readonly Bindings bindings = new Bindings();
+
+		[SetUp]
+		public void Setup()
+		{
+			scope.SetVar("a", true);
+			scope.SetVar("b", false);
+		}
+
+		public Value Eval(Expression exp)
+		{
+			return exp.Evaluate(scope, bindings);
+		}
+
+		#region Bool and Bool
+
+		[Test]
+		public void BoolPlusBool()
+		{
+			var ab = new AddExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new AddExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolMinusBool()
+		{
+			var ab = new SubtractExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new SubtractExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolTimesBool()
+		{
+			var ab = new MultiplyExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new MultiplyExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolDividedByBool()
+		{
+			var ab = new DivideExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new DivideExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolAndBool()
+		{
+			var ab = new BoolAndExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new BoolAndExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void BoolOrBool()
+		{
+			var ab = new BoolOrExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolOrExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void BoolXorBool()
+		{
+			var ab = new BoolXorExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolXorExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void BoolEqualsBool()
+		{
+			var aa = new EqualsExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new EqualsExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+		}
+
+		[Test]
+		public void BoolNotEqualsBool()
+		{
+			var aa = new NotEqualsExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new NotEqualsExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+		}
+
+		[Test]
+		public void BoolGreaterThanBool()
+		{
+			var ab = new GreaterThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new GreaterThanExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolGreaterThanOrEqualBool()
+		{
+			var ab = new GreaterThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new GreaterThanOrEqualExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolLessThanBool()
+		{
+			var ab = new LessThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new LessThanExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void BoolLessThanOrEqualBool()
+		{
+			var ab = new LessThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new LessThanOrEqualExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		#endregion
+
+		#region Bool and Null
+
+		[Test]
+		public void BoolPlusNull()
+		{
+			var an = new AddExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new AddExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolMinusNull()
+		{
+			var an = new SubtractExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new SubtractExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolTimesNull()
+		{
+			var an = new MultiplyExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new MultiplyExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolDividedByNull()
+		{
+			var an = new DivideExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new DivideExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolAndNull()
+		{
+			var an = new BoolAndExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolAndExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void BoolOrNull()
+		{
+			var an = new BoolOrExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolOrExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void BoolXorNull()
+		{
+			var an = new BoolXorExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolXorExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void BoolEqualsNull()
+		{
+			var an = new EqualsExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new EqualsExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void BoolNotEqualsNull()
+		{
+			var an = new NotEqualsExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new NotEqualsExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void BoolGreaterThanNull()
+		{
+			var an = new GreaterThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolGreaterThanOrEqualNull()
+		{
+			var an = new GreaterThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolLessThanNull()
+		{
+			var an = new LessThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void BoolLessThanOrEqualNull()
+		{
+			var an = new LessThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		#endregion
+	}
+}
+
+#endif

--- a/Editor/Tests/Expressions/BoolExpressionTest.cs.meta
+++ b/Editor/Tests/Expressions/BoolExpressionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16fcd6fe769fd734b94774f2a28efe6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tests/Expressions/DotTest.cs
+++ b/Editor/Tests/Expressions/DotTest.cs
@@ -40,7 +40,9 @@ namespace Exodrifter.Rumor.Test.Expressions
 				new VariableExpression("o"),
 				new VariableExpression("imaginaryInt")
 			);
-			Assert.AreEqual(null, exp.Evaluate(scope, bindings).AsObject());
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
 		}
 
 		/// <summary>
@@ -71,53 +73,26 @@ namespace Exodrifter.Rumor.Test.Expressions
 				new VariableExpression("o"),
 				new FunctionExpression("imaginaryMethod")
 			);
-			Assert.AreEqual(null, exp.Evaluate(scope, bindings).AsObject());
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
 		}
 
 		/// <summary>
-		/// Check that member access on primitives does not work.
+		/// Check that member access on primitives works.
 		/// </summary>
 		[Test]
 		public void PrimitiveDotMember()
 		{
 			var scope = new Scope();
 			var bindings = new Bindings();
-			scope.SetVar("bool", true);
-			scope.SetVar("int", 1);
-			scope.SetVar("float", 1f);
 			scope.SetVar("string", "str");
 
 			var exp = new DotExpression(
-				new VariableExpression("bool"),
-				new VariableExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("int"),
-				new VariableExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("float"),
-				new VariableExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
 				new VariableExpression("string"),
-				new VariableExpression("foo")
+				new VariableExpression("Length")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(3, exp.Evaluate(scope, bindings).AsObject());
 		}
 
 		[Test]
@@ -132,35 +107,27 @@ namespace Exodrifter.Rumor.Test.Expressions
 
 			var exp = new DotExpression(
 				new VariableExpression("bool"),
-				new FunctionExpression("foo")
+				new FunctionExpression("GetType")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(typeof(bool), exp.Evaluate(scope, bindings).AsObject());
 
 			exp = new DotExpression(
 				new VariableExpression("int"),
-				new FunctionExpression("foo")
+				new FunctionExpression("GetType")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(typeof(int), exp.Evaluate(scope, bindings).AsObject());
 
 			exp = new DotExpression(
 				new VariableExpression("float"),
-				new FunctionExpression("foo")
+				new FunctionExpression("GetType")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(typeof(float), exp.Evaluate(scope, bindings).AsObject());
 
 			exp = new DotExpression(
 				new VariableExpression("string"),
-				new FunctionExpression("foo")
+				new FunctionExpression("GetType")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(typeof(string), exp.Evaluate(scope, bindings).AsObject());
 		}
 
 		/// <summary>

--- a/Editor/Tests/Expressions/DotTest.cs
+++ b/Editor/Tests/Expressions/DotTest.cs
@@ -8,7 +8,7 @@ using System;
 namespace Exodrifter.Rumor.Test.Expressions
 {
 	/// <summary>
-	/// Ensure dot operators work as expected
+	/// Ensure dot operators work as expected.
 	/// </summary>
 	public class DotTest
 	{
@@ -16,50 +16,147 @@ namespace Exodrifter.Rumor.Test.Expressions
 		/// Check if member access on objects work.
 		/// </summary>
 		[Test]
-		public void Member()
+		public void ObjectDotMember()
 		{
 			var scope = new Scope();
 			var bindings = new Bindings();
 			scope.SetVar("o", new Test(1, 2));
 
-			// Public
 			var exp = new DotExpression(
 				new VariableExpression("o"),
-				new VariableExpression("a")
+				new VariableExpression("publicInt")
 			);
-			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsInt());
+			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsObject());
 
-			// Private
 			exp = new DotExpression(
 				new VariableExpression("o"),
-				new VariableExpression("b")
+				new VariableExpression("privateInt")
 			);
 			Assert.Throws<InvalidOperationException>(
 				() => exp.Evaluate(scope, bindings)
 			);
+
+			exp = new DotExpression(
+				new VariableExpression("o"),
+				new VariableExpression("imaginaryInt")
+			);
+			Assert.AreEqual(null, exp.Evaluate(scope, bindings).AsObject());
 		}
 
 		/// <summary>
 		/// Check if function access on objects work.
 		/// </summary>
 		[Test]
-		public void Function()
+		public void ObjectDotFunction()
 		{
 			var scope = new Scope();
 			var bindings = new Bindings();
 			scope.SetVar("o", new Test(1, 2));
 
-			// Public
 			var exp = new DotExpression(
 				new VariableExpression("o"),
-				new FunctionExpression("foo")
+				new FunctionExpression("publicMethod")
 			);
-			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsInt());
+			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsObject());
 
-			// Private
 			exp = new DotExpression(
 				new VariableExpression("o"),
-				new FunctionExpression("bar")
+				new FunctionExpression("privateMethod")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("o"),
+				new FunctionExpression("imaginaryMethod")
+			);
+			Assert.AreEqual(null, exp.Evaluate(scope, bindings).AsObject());
+		}
+
+		/// <summary>
+		/// Check that member access on primitives does not work.
+		/// </summary>
+		[Test]
+		public void PrimitiveDotMember()
+		{
+			var scope = new Scope();
+			var bindings = new Bindings();
+			scope.SetVar("bool", true);
+			scope.SetVar("int", 1);
+			scope.SetVar("float", 1f);
+			scope.SetVar("string", "str");
+
+			var exp = new DotExpression(
+				new VariableExpression("bool"),
+				new VariableExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("int"),
+				new VariableExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("float"),
+				new VariableExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("string"),
+				new VariableExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+		}
+
+		[Test]
+		public void PrimitiveDotFunction()
+		{
+			var scope = new Scope();
+			var bindings = new Bindings();
+			scope.SetVar("bool", true);
+			scope.SetVar("int", 1);
+			scope.SetVar("float", 1f);
+			scope.SetVar("string", "str");
+
+			var exp = new DotExpression(
+				new VariableExpression("bool"),
+				new FunctionExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("int"),
+				new FunctionExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("float"),
+				new FunctionExpression("foo")
+			);
+			Assert.Throws<InvalidOperationException>(
+				() => exp.Evaluate(scope, bindings)
+			);
+
+			exp = new DotExpression(
+				new VariableExpression("string"),
+				new FunctionExpression("foo")
 			);
 			Assert.Throws<InvalidOperationException>(
 				() => exp.Evaluate(scope, bindings)
@@ -67,96 +164,37 @@ namespace Exodrifter.Rumor.Test.Expressions
 		}
 
 		/// <summary>
-		/// Make sure dot operators can only be called on objects.
+		/// Check that member access on null always returns null.
 		/// </summary>
 		[Test]
-		public void Invalid()
+		public void NullDot()
 		{
 			var scope = new Scope();
 			var bindings = new Bindings();
-			scope.SetVar("o", new Test(1, 2));
-			scope.SetVar("bool", true);
-			scope.SetVar("int", 1);
-			scope.SetVar("float", 1f);
-			scope.SetVar("string", "str");
 
-			// Member access
 			var exp = new DotExpression(
-				new VariableExpression("bool"),
+				new VariableExpression("null"),
 				new VariableExpression("foo")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(null, exp.Evaluate(scope, bindings).AsObject());
 
 			exp = new DotExpression(
-				new VariableExpression("int"),
-				new VariableExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("float"),
-				new VariableExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("string"),
-				new VariableExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			// Function access
-			exp = new DotExpression(
-				new VariableExpression("bool"),
+				new VariableExpression("null"),
 				new FunctionExpression("foo")
 			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("int"),
-				new FunctionExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("float"),
-				new FunctionExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
-
-			exp = new DotExpression(
-				new VariableExpression("string"),
-				new FunctionExpression("foo")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings)
-			);
+			Assert.AreEqual(null, exp.Evaluate(scope, bindings).AsObject());
 		}
 	}
 
 	class Test
 	{
-		public int a;
-		private int b;
+		public int publicInt;
+		private int privateInt;
 
-		public Test(int a, int b) { this.a = a; this.b = b; }
+		public Test(int a, int b) { publicInt = a; privateInt = b; }
 
-		public int foo() { return a; }
-		private int bar() { return b; }
+		public int publicMethod() { return publicInt; }
+		private int privateMethod() { return privateInt; }
 	}
 }
 

--- a/Editor/Tests/Expressions/FloatExpressionTest.cs
+++ b/Editor/Tests/Expressions/FloatExpressionTest.cs
@@ -1,0 +1,342 @@
+﻿#if UNITY_EDITOR
+
+using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
+using NUnit.Framework;
+using System;
+
+/// <summary>
+/// Tests expressions with float and null as the left and right arguments.
+/// </summary>
+namespace Exodrifter.Rumor.Test.Expressions
+{
+	public class FloatExpressionTest
+	{
+		private readonly VariableExpression varA = new VariableExpression("a");
+		private readonly VariableExpression varB = new VariableExpression("b");
+		private readonly VariableExpression varNull = new VariableExpression("null");
+		private readonly Scope scope = new Scope();
+		private readonly Bindings bindings = new Bindings();
+
+		[SetUp]
+		public void Setup()
+		{
+			scope.SetVar("a", 1f);
+			scope.SetVar("b", 0f);
+		}
+
+		public Value Eval(Expression exp)
+		{
+			return exp.Evaluate(scope, bindings);
+		}
+
+		#region Float and Float
+
+		[Test]
+		public void FloatPlusFloat()
+		{
+			var aa = new AddExpression(varA, varA);
+			Assert.AreEqual(2f, Eval(aa).AsObject());
+
+			var ab = new AddExpression(varA, varB);
+			Assert.AreEqual(1f, Eval(ab).AsObject());
+
+			var ba = new AddExpression(varB, varA);
+			Assert.AreEqual(1f, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatMinusFloat()
+		{
+			var aa = new AddExpression(varA, varA);
+			Assert.AreEqual(0f, Eval(aa).AsObject());
+
+			var ab = new SubtractExpression(varA, varB);
+			Assert.AreEqual(1f, Eval(ab).AsObject());
+
+			var ba = new SubtractExpression(varB, varA);
+			Assert.AreEqual(-1f, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatTimesFloat()
+		{
+			var aa = new MultiplyExpression(varA, varA);
+			Assert.AreEqual(1f, Eval(aa).AsObject());
+
+			var ab = new MultiplyExpression(varA, varB);
+			Assert.AreEqual(0f, Eval(ab).AsObject());
+
+			var ba = new MultiplyExpression(varB, varA);
+			Assert.AreEqual(0f, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatDividedByFloat()
+		{
+			var aa = new DivideExpression(varA, varA);
+			Assert.AreEqual(1f, Eval(aa).AsObject());
+
+			var ab = new DivideExpression(varA, varB);
+			Assert.Throws<DivideByZeroException>(() => Eval(ab).AsObject());
+
+			var ba = new DivideExpression(varB, varA);
+			Assert.AreEqual(0f, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatAndFloat()
+		{
+			var aa = new BoolAndExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new BoolAndExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new BoolAndExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatOrFloat()
+		{
+			var aa = new BoolOrExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new BoolOrExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolOrExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatXorFloat()
+		{
+			var aa = new BoolXorExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new BoolXorExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolXorExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatEqualsFloat()
+		{
+			var aa = new EqualsExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new EqualsExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new EqualsExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatNotEqualsFloat()
+		{
+			var aa = new NotEqualsExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new NotEqualsExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new NotEqualsExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatGreaterThanFloat()
+		{
+			var aa = new GreaterThanExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new GreaterThanExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new GreaterThanExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatGreaterThanOrEqualFloat()
+		{
+			var aa = new GreaterThanOrEqualExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new GreaterThanOrEqualExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new GreaterThanOrEqualExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatLessThanFloat()
+		{
+			var aa = new LessThanExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new LessThanExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new LessThanExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void FloatLessThanOrEqualFloat()
+		{
+			var aa = new LessThanOrEqualExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new LessThanOrEqualExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new LessThanOrEqualExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		#endregion
+
+		#region Float and Null
+
+		[Test]
+		public void FloatPlusNull()
+		{
+			var an = new AddExpression(varA, varNull);
+			Assert.AreEqual(1f, Eval(an).AsObject());
+
+			var na = new AddExpression(varNull, varA);
+			Assert.AreEqual(1f, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void FloatMinusNull()
+		{
+			var an = new SubtractExpression(varA, varNull);
+			Assert.AreEqual(1f, Eval(an).AsObject());
+
+			var na = new SubtractExpression(varNull, varA);
+			Assert.AreEqual(-1f, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void FloatTimesNull()
+		{
+			var an = new MultiplyExpression(varA, varNull);
+			Assert.AreEqual(0f, Eval(an).AsObject());
+
+			var na = new MultiplyExpression(varNull, varA);
+			Assert.AreEqual(0f, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void FloatDividedByNull()
+		{
+			var an = new DivideExpression(varA, varNull);
+			Assert.Throws<DivideByZeroException>(() => Eval(an).AsObject());
+
+			var na = new DivideExpression(varNull, varA);
+			Assert.AreEqual(0f, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void FloatAndNull()
+		{
+			var an = new BoolAndExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsBool());
+
+			var na = new BoolAndExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsBool());
+		}
+
+		[Test]
+		public void FloatOrNull()
+		{
+			var an = new BoolOrExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsBool());
+
+			var na = new BoolOrExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsBool());
+		}
+
+		[Test]
+		public void FloatXorNull()
+		{
+			var an = new BoolXorExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsBool());
+
+			var na = new BoolXorExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsBool());
+		}
+
+		[Test]
+		public void FloatEqualsNull()
+		{
+			var an = new EqualsExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsBool());
+
+			var na = new EqualsExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsBool());
+		}
+
+		[Test]
+		public void FloatNotEqualsNull()
+		{
+			var an = new NotEqualsExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsBool());
+
+			var na = new NotEqualsExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsBool());
+		}
+
+		[Test]
+		public void FloatGreaterThanNull()
+		{
+			var an = new GreaterThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void FloatGreaterThanOrEqualNull()
+		{
+			var an = new GreaterThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void FloatLessThanNull()
+		{
+			var an = new LessThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void FloatLessThanOrEqualNull()
+		{
+			var an = new LessThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		#endregion
+	}
+}
+
+#endif

--- a/Editor/Tests/Expressions/FloatExpressionTest.cs
+++ b/Editor/Tests/Expressions/FloatExpressionTest.cs
@@ -48,7 +48,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 		[Test]
 		public void FloatMinusFloat()
 		{
-			var aa = new AddExpression(varA, varA);
+			var aa = new SubtractExpression(varA, varA);
 			Assert.AreEqual(0f, Eval(aa).AsObject());
 
 			var ab = new SubtractExpression(varA, varB);

--- a/Editor/Tests/Expressions/FloatExpressionTest.cs.meta
+++ b/Editor/Tests/Expressions/FloatExpressionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75034ad7ba4651541b1a550d5ed9350d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tests/Expressions/IntExpressionTest.cs
+++ b/Editor/Tests/Expressions/IntExpressionTest.cs
@@ -1,0 +1,342 @@
+﻿#if UNITY_EDITOR
+
+using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
+using NUnit.Framework;
+using System;
+
+/// <summary>
+/// Tests expressions with int and null as the left and right arguments.
+/// </summary>
+namespace Exodrifter.Rumor.Test.Expressions
+{
+	public class IntExpressionTest
+	{
+		private readonly VariableExpression varA = new VariableExpression("a");
+		private readonly VariableExpression varB = new VariableExpression("b");
+		private readonly VariableExpression varNull = new VariableExpression("null");
+		private readonly Scope scope = new Scope();
+		private readonly Bindings bindings = new Bindings();
+
+		[SetUp]
+		public void Setup()
+		{
+			scope.SetVar("a", 1);
+			scope.SetVar("b", 0);
+		}
+
+		public Value Eval(Expression exp)
+		{
+			return exp.Evaluate(scope, bindings);
+		}
+
+		#region Int and Int
+
+		[Test]
+		public void IntPlusInt()
+		{
+			var aa = new AddExpression(varA, varA);
+			Assert.AreEqual(2, Eval(aa).AsObject());
+
+			var ab = new AddExpression(varA, varB);
+			Assert.AreEqual(1, Eval(ab).AsObject());
+
+			var ba = new AddExpression(varB, varA);
+			Assert.AreEqual(1, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntMinusInt()
+		{
+			var aa = new SubtractExpression(varA, varA);
+			Assert.AreEqual(0, Eval(aa).AsObject());
+
+			var ab = new SubtractExpression(varA, varB);
+			Assert.AreEqual(1, Eval(ab).AsObject());
+
+			var ba = new SubtractExpression(varB, varA);
+			Assert.AreEqual(-1, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntTimesInt()
+		{
+			var aa = new MultiplyExpression(varA, varA);
+			Assert.AreEqual(1, Eval(aa).AsObject());
+
+			var ab = new MultiplyExpression(varA, varB);
+			Assert.AreEqual(0, Eval(ab).AsObject());
+
+			var ba = new MultiplyExpression(varB, varA);
+			Assert.AreEqual(0, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntDividedByInt()
+		{
+			var aa = new DivideExpression(varA, varA);
+			Assert.AreEqual(1, Eval(aa).AsObject());
+
+			var ab = new DivideExpression(varA, varB);
+			Assert.Throws<DivideByZeroException>(() => Eval(ab).AsObject());
+
+			var ba = new DivideExpression(varB, varA);
+			Assert.AreEqual(0, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntAndInt()
+		{
+			var aa = new BoolAndExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new BoolAndExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new BoolAndExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntOrInt()
+		{
+			var aa = new BoolOrExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new BoolOrExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolOrExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntXorInt()
+		{
+			var aa = new BoolXorExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new BoolXorExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolXorExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntEqualsInt()
+		{
+			var aa = new EqualsExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new EqualsExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new EqualsExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntNotEqualsInt()
+		{
+			var aa = new NotEqualsExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new NotEqualsExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new NotEqualsExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntGreaterThanInt()
+		{
+			var aa = new GreaterThanExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new GreaterThanExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new GreaterThanExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntGreaterThanOrEqualInt()
+		{
+			var aa = new GreaterThanOrEqualExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new GreaterThanOrEqualExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new GreaterThanOrEqualExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntLessThanInt()
+		{
+			var aa = new LessThanExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new LessThanExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new LessThanExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void IntLessThanOrEqualInt()
+		{
+			var aa = new LessThanOrEqualExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new LessThanOrEqualExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new LessThanOrEqualExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		#endregion
+
+		#region Int and Null
+
+		[Test]
+		public void IntPlusNull()
+		{
+			var an = new AddExpression(varA, varNull);
+			Assert.AreEqual(1, Eval(an).AsObject());
+
+			var na = new AddExpression(varNull, varA);
+			Assert.AreEqual(1, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntMinusNull()
+		{
+			var an = new SubtractExpression(varA, varNull);
+			Assert.AreEqual(1, Eval(an).AsObject());
+
+			var na = new SubtractExpression(varNull, varA);
+			Assert.AreEqual(-1, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntTimesNull()
+		{
+			var an = new MultiplyExpression(varA, varNull);
+			Assert.AreEqual(0, Eval(an).AsObject());
+
+			var na = new MultiplyExpression(varNull, varA);
+			Assert.AreEqual(0, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntDividedByNull()
+		{
+			var an = new DivideExpression(varA, varNull);
+			Assert.Throws<DivideByZeroException>(() => Eval(an).AsObject());
+
+			var na = new DivideExpression(varNull, varA);
+			Assert.AreEqual(0, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntAndNull()
+		{
+			var an = new BoolAndExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolAndExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntOrNull()
+		{
+			var an = new BoolOrExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolOrExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntXorNull()
+		{
+			var an = new BoolXorExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolXorExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntEqualsNull()
+		{
+			var an = new EqualsExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new EqualsExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntNotEqualsNull()
+		{
+			var an = new NotEqualsExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new NotEqualsExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void IntGreaterThanNull()
+		{
+			var an = new GreaterThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void IntGreaterThanOrEqualNull()
+		{
+			var an = new GreaterThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void IntLessThanNull()
+		{
+			var an = new LessThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void IntLessThanOrEqualNull()
+		{
+			var an = new LessThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		#endregion
+	}
+}
+
+#endif

--- a/Editor/Tests/Expressions/IntExpressionTest.cs.meta
+++ b/Editor/Tests/Expressions/IntExpressionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9ce51911c19cf84885f19bee3c6b21f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tests/Expressions/LiteralTest.cs
+++ b/Editor/Tests/Expressions/LiteralTest.cs
@@ -8,13 +8,13 @@ namespace Exodrifter.Rumor.Test.Expressions
 	/// <summary>
 	/// Ensure Literal expressions operate as expected.
 	/// </summary>
-	public class LiteralExpressionTest
+	public class LiteralTest
 	{
 		/// <summary>
 		/// Check the constructors of literal expressions.
 		/// </summary>
 		[Test]
-		public void LiteralExpressionConstructor()
+		public void LiteralConstructor()
 		{
 			var a = new LiteralExpression(1);
 			Assert.AreEqual(a.Value.GetType(), typeof(IntValue));

--- a/Editor/Tests/Expressions/NullExpressions.cs
+++ b/Editor/Tests/Expressions/NullExpressions.cs
@@ -5,334 +5,156 @@ using Exodrifter.Rumor.Expressions;
 using NUnit.Framework;
 using System;
 
+/// <summary>
+/// Tests expressions with null as the left and right arguments.
+/// </summary>
 namespace Exodrifter.Rumor.Test.Expressions
 {
-	/// <summary>
-	/// Ensure expressions work as expected when provided null values.
-	/// </summary>
-	public class NullExpressionsTest
+	public class NullExpressionTest
 	{
-		/// <summary>
-		/// Tests operations with null and bool values.
-		/// </summary>
-		[Test]
-		public void NullAndBool()
+		private readonly VariableExpression varA = new VariableExpression("a");
+		private readonly VariableExpression varB = new VariableExpression("b");
+		private readonly Scope scope = new Scope();
+		private readonly Bindings bindings = new Bindings();
+
+		public Value Eval(Expression exp)
 		{
-			var scope = new Scope();
-			var bindings = new Bindings();
-			scope.SetVar("a", true);
-
-			Expression exp = new AddExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new AddExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new SubtractExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new SubtractExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new MultiplyExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new MultiplyExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new DivideExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new DivideExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new BoolAndExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolAndExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-
-			exp = new BoolOrExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolOrExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
+			return exp.Evaluate(scope, bindings);
 		}
 
-		/// <summary>
-		/// Tests operations with null and int values.
-		/// </summary>
+		#region Null and Null
+
 		[Test]
-		public void NullAndInt()
+		public void NullPlusNull()
 		{
-			var scope = new Scope();
-			var bindings = new Bindings();
-			scope.SetVar("a", 1);
+			var an = new AddExpression(varA, varB);
+			Assert.AreEqual(null, Eval(an).AsObject());
 
-			Expression exp = new AddExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsInt());
-			exp = new AddExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsInt());
-
-			exp = new SubtractExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(1, exp.Evaluate(scope, bindings).AsInt());
-			exp = new SubtractExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(-1, exp.Evaluate(scope, bindings).AsInt());
-
-			exp = new MultiplyExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(0, exp.Evaluate(scope, bindings).AsInt());
-			exp = new MultiplyExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(0, exp.Evaluate(scope, bindings).AsInt());
-
-			exp = new DivideExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(0, exp.Evaluate(scope, bindings).AsInt());
-			exp = new DivideExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(0, exp.Evaluate(scope, bindings).AsInt());
-
-			exp = new BoolAndExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolAndExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-
-			exp = new BoolOrExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolOrExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
+			var na = new AddExpression(varB, varA);
+			Assert.AreEqual(null, Eval(na).AsObject());
 		}
 
-		/// <summary>
-		/// Tests operations with null and float values.
-		/// </summary>
 		[Test]
-		public void NullAndFloat()
+		public void NullMinusNull()
 		{
-			var scope = new Scope();
-			var bindings = new Bindings();
-			scope.SetVar("a", 1f);
+			var an = new SubtractExpression(varA, varB);
+			Assert.AreEqual(null, Eval(an).AsObject());
 
-			Expression exp = new AddExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(1f, exp.Evaluate(scope, bindings).AsFloat());
-			exp = new AddExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(1f, exp.Evaluate(scope, bindings).AsFloat());
-
-			exp = new SubtractExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(1f, exp.Evaluate(scope, bindings).AsFloat());
-			exp = new SubtractExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(-1f, exp.Evaluate(scope, bindings).AsFloat());
-
-			exp = new MultiplyExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(0f, exp.Evaluate(scope, bindings).AsFloat());
-			exp = new MultiplyExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(0f, exp.Evaluate(scope, bindings).AsFloat());
-
-			exp = new DivideExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(0f, exp.Evaluate(scope, bindings).AsFloat());
-			exp = new DivideExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(0f, exp.Evaluate(scope, bindings).AsFloat());
-
-			exp = new BoolAndExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolAndExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-
-			exp = new BoolOrExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolOrExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
+			var na = new SubtractExpression(varB, varA);
+			Assert.AreEqual(null, Eval(na).AsObject());
 		}
 
-		/// <summary>
-		/// Tests operations with null and string values.
-		/// </summary>
 		[Test]
-		public void NullAndString()
+		public void NullTimesNull()
 		{
-			var scope = new Scope();
-			var bindings = new Bindings();
-			scope.SetVar("a", "1");
+			var an = new MultiplyExpression(varA, varB);
+			Assert.AreEqual(null, Eval(an).AsObject());
 
-			Expression exp = new AddExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual("1", exp.Evaluate(scope, bindings).AsString());
-			exp = new AddExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual("1", exp.Evaluate(scope, bindings).AsString());
-
-			exp = new SubtractExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new SubtractExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new MultiplyExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new MultiplyExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new DivideExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-			exp = new DivideExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.Throws<InvalidOperationException>(
-				() => exp.Evaluate(scope, bindings).AsString());
-
-			exp = new BoolAndExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolAndExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(false, exp.Evaluate(scope, bindings).AsBool());
-
-			exp = new BoolOrExpression(
-				new VariableExpression("a"),
-				new VariableExpression("b")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
-			exp = new BoolOrExpression(
-				new VariableExpression("b"),
-				new VariableExpression("a")
-			);
-			Assert.AreEqual(true, exp.Evaluate(scope, bindings).AsBool());
+			var na = new MultiplyExpression(varB, varA);
+			Assert.AreEqual(null, Eval(na).AsObject());
 		}
+
+		[Test]
+		public void NullDividedByNull()
+		{
+			var an = new DivideExpression(varA, varB);
+			Assert.AreEqual(null, Eval(an).AsObject());
+
+			var na = new DivideExpression(varB, varA);
+			Assert.AreEqual(null, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void NullAndNull()
+		{
+			var an = new BoolAndExpression(varA, varB);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolAndExpression(varB, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void NullOrNull()
+		{
+			var an = new BoolOrExpression(varA, varB);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolOrExpression(varB, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void NullXorNull()
+		{
+			var an = new BoolXorExpression(varA, varB);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolXorExpression(varB, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void NullEqualsNull()
+		{
+			var an = new EqualsExpression(varA, varB);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new EqualsExpression(varB, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void NullNotEqualsNull()
+		{
+			var an = new NotEqualsExpression(varA, varB);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new NotEqualsExpression(varB, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void NullGreaterThanNull()
+		{
+			var an = new GreaterThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void NullGreaterThanOrEqualNull()
+		{
+			var an = new GreaterThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanOrEqualExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void NullLessThanNull()
+		{
+			var an = new LessThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void NullLessThanOrEqualNull()
+		{
+			var an = new LessThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanOrEqualExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		#endregion
 	}
 }
 

--- a/Editor/Tests/Expressions/ObjectExpressionTest.cs
+++ b/Editor/Tests/Expressions/ObjectExpressionTest.cs
@@ -1,0 +1,310 @@
+﻿#if UNITY_EDITOR
+
+using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
+using NUnit.Framework;
+using System;
+
+/// <summary>
+/// Tests expressions with boolean and null as the left and right arguments.
+/// </summary>
+namespace Exodrifter.Rumor.Test.Expressions
+{
+	public class ObjectExpressionTest
+	{
+		private readonly VariableExpression varA = new VariableExpression("a");
+		private readonly VariableExpression varB = new VariableExpression("b");
+		private readonly VariableExpression varNull = new VariableExpression("null");
+		private readonly Scope scope = new Scope();
+		private readonly Bindings bindings = new Bindings();
+
+		[SetUp]
+		public void Setup()
+		{
+			scope.SetVar("a", new object());
+			// `b` is not null because that is the same as undefined
+			scope.SetVar("b", new object());
+		}
+
+		public Value Eval(Expression exp)
+		{
+			return exp.Evaluate(scope, bindings);
+		}
+
+		#region Object and Object
+
+		[Test]
+		public void ObjectPlusObject()
+		{
+			var ab = new AddExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new AddExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectMinusObject()
+		{
+			var ab = new SubtractExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new SubtractExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectTimesObject()
+		{
+			var ab = new MultiplyExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new MultiplyExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectDividedByObject()
+		{
+			var ab = new DivideExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new DivideExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectAndObject()
+		{
+			var ab = new BoolAndExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolAndExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void ObjectOrObject()
+		{
+			var ab = new BoolOrExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new BoolOrExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsBool());
+		}
+
+		[Test]
+		public void ObjectXorObject()
+		{
+			var ab = new BoolXorExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsBool());
+
+			var ba = new BoolXorExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsBool());
+		}
+
+		[Test]
+		public void ObjectEqualsObject()
+		{
+			var aa = new EqualsExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsBool());
+
+			var ab = new EqualsExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsBool());
+
+			var ba = new EqualsExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsBool());
+		}
+
+		[Test]
+		public void ObjectNotEqualsObject()
+		{
+			var aa = new NotEqualsExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsBool());
+
+			var ab = new NotEqualsExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsBool());
+
+			var ba = new NotEqualsExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsBool());
+		}
+
+		[Test]
+		public void ObjectGreaterThanObject()
+		{
+			var ab = new GreaterThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new GreaterThanExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectGreaterThanOrEqualObject()
+		{
+			var ab = new GreaterThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new GreaterThanOrEqualExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectLessThanObject()
+		{
+			var ab = new LessThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new LessThanExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void ObjectLessThanOrEqualObject()
+		{
+			var ab = new LessThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new LessThanOrEqualExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		#endregion
+
+		#region Object and Null
+
+		[Test]
+		public void ObjectPlusNull()
+		{
+			var an = new AddExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new AddExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectMinusNull()
+		{
+			var an = new SubtractExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new SubtractExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectTimesNull()
+		{
+			var an = new MultiplyExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new MultiplyExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectDividedByNull()
+		{
+			var an = new DivideExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new DivideExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectAndNull()
+		{
+			var an = new BoolAndExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolAndExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void ObjectOrNull()
+		{
+			var an = new BoolOrExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolOrExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void ObjectXorNull()
+		{
+			var an = new BoolXorExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolXorExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void ObjectEqualsNull()
+		{
+			var an = new EqualsExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new EqualsExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void ObjectNotEqualsNull()
+		{
+			var an = new NotEqualsExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new NotEqualsExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void ObjectGreaterThanNull()
+		{
+			var an = new GreaterThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectGreaterThanOrEqualNull()
+		{
+			var an = new GreaterThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectLessThanNull()
+		{
+			var an = new LessThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void ObjectLessThanOrEqualNull()
+		{
+			var an = new LessThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		#endregion
+	}
+}
+
+#endif

--- a/Editor/Tests/Expressions/ObjectExpressionTest.cs.meta
+++ b/Editor/Tests/Expressions/ObjectExpressionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cd92a3135742b3468e39a535076026a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tests/Expressions/StringExpressionTest.cs
+++ b/Editor/Tests/Expressions/StringExpressionTest.cs
@@ -1,0 +1,362 @@
+﻿#if UNITY_EDITOR
+
+using Exodrifter.Rumor.Engine;
+using Exodrifter.Rumor.Expressions;
+using NUnit.Framework;
+using System;
+
+/// <summary>
+/// Tests expressions with string and null as the left and right arguments.
+/// </summary>
+namespace Exodrifter.Rumor.Test.Expressions
+{
+	public class StringExpressionTest
+	{
+		private readonly VariableExpression varA = new VariableExpression("a");
+		private readonly VariableExpression varB = new VariableExpression("b");
+		private readonly VariableExpression varEmpty = new VariableExpression("empty");
+		private readonly VariableExpression varNull = new VariableExpression("null");
+		private readonly Scope scope = new Scope();
+		private readonly Bindings bindings = new Bindings();
+
+		[SetUp]
+		public void Setup()
+		{
+			scope.SetVar("a", "a");
+			scope.SetVar("b", "b");
+			scope.SetVar("empty", "");
+		}
+
+		public Value Eval(Expression exp)
+		{
+			return exp.Evaluate(scope, bindings);
+		}
+
+		#region String and String
+
+		[Test]
+		public void StringPlusString()
+		{
+			var ae = new AddExpression(varA, varEmpty);
+			Assert.AreEqual("a", Eval(ae).AsObject());
+
+			var ab = new AddExpression(varA, varB);
+			Assert.AreEqual("ab", Eval(ab).AsObject());
+
+			var ba = new AddExpression(varB, varA);
+			Assert.AreEqual("ba", Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void StringMinusString()
+		{
+			var ab = new SubtractExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new SubtractExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void StringTimesString()
+		{
+			var ab = new MultiplyExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new MultiplyExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void StringDividedByString()
+		{
+			var ab = new DivideExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+
+			var ba = new DivideExpression(varB, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(ba));
+		}
+
+		[Test]
+		public void StringAndString()
+		{
+			var ee = new BoolAndExpression(varEmpty, varEmpty);
+			Assert.AreEqual(false, Eval(ee).AsObject());
+
+			var ae = new BoolAndExpression(varA, varEmpty);
+			Assert.AreEqual(false, Eval(ae).AsObject());
+
+			var ea = new BoolAndExpression(varEmpty, varA);
+			Assert.AreEqual(false, Eval(ea).AsObject());
+
+			var ab = new BoolAndExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+		}
+
+		[Test]
+		public void StringOrString()
+		{
+			var ee = new BoolOrExpression(varEmpty, varEmpty);
+			Assert.AreEqual(false, Eval(ee).AsObject());
+
+			var ae = new BoolOrExpression(varA, varEmpty);
+			Assert.AreEqual(true, Eval(ae).AsObject());
+
+			var ea = new BoolOrExpression(varEmpty, varA);
+			Assert.AreEqual(true, Eval(ea).AsObject());
+
+			var ab = new BoolOrExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+		}
+
+		[Test]
+		public void StringXorString()
+		{
+			var ee = new BoolXorExpression(varEmpty, varEmpty);
+			Assert.AreEqual(false, Eval(ee).AsObject());
+
+			var ae = new BoolXorExpression(varA, varEmpty);
+			Assert.AreEqual(true, Eval(ae).AsObject());
+
+			var ea = new BoolXorExpression(varEmpty, varA);
+			Assert.AreEqual(true, Eval(ea).AsObject());
+
+			var ab = new BoolXorExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+		}
+
+		[Test]
+		public void StringEqualsString()
+		{
+			var ee = new EqualsExpression(varEmpty, varEmpty);
+			Assert.AreEqual(true, Eval(ee).AsObject());
+
+			var aa = new EqualsExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ab = new EqualsExpression(varA, varB);
+			Assert.AreEqual(false, Eval(ab).AsObject());
+
+			var ba = new EqualsExpression(varB, varA);
+			Assert.AreEqual(false, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void StringNotEqualsString()
+		{
+			var ee = new NotEqualsExpression(varEmpty, varEmpty);
+			Assert.AreEqual(false, Eval(ee).AsObject());
+
+			var aa = new NotEqualsExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ab = new NotEqualsExpression(varA, varB);
+			Assert.AreEqual(true, Eval(ab).AsObject());
+
+			var ba = new NotEqualsExpression(varB, varA);
+			Assert.AreEqual(true, Eval(ba).AsObject());
+		}
+
+		[Test]
+		public void StringGreaterThanString()
+		{
+			var ee = new GreaterThanExpression(varEmpty, varEmpty);
+			Assert.Throws<InvalidOperationException>(() => Eval(ee));
+
+			var aa = new GreaterThanExpression(varA, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(aa));
+
+			var ab = new GreaterThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+		}
+
+		[Test]
+		public void StringGreaterThanOrEqualString()
+		{
+			var ee = new GreaterThanOrEqualExpression(varEmpty, varEmpty);
+			Assert.Throws<InvalidOperationException>(() => Eval(ee));
+
+			var aa = new GreaterThanOrEqualExpression(varA, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(aa));
+
+			var ab = new GreaterThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+		}
+
+		[Test]
+		public void StringLessThanString()
+		{
+			var ee = new LessThanExpression(varEmpty, varEmpty);
+			Assert.Throws<InvalidOperationException>(() => Eval(ee));
+
+			var aa = new LessThanExpression(varA, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(aa));
+
+			var ab = new LessThanExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+		}
+
+		[Test]
+		public void StringLessThanOrEqualString()
+		{
+			var ee = new LessThanOrEqualExpression(varEmpty, varEmpty);
+			Assert.Throws<InvalidOperationException>(() => Eval(ee));
+
+			var aa = new LessThanOrEqualExpression(varA, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(aa));
+
+			var ab = new LessThanOrEqualExpression(varA, varB);
+			Assert.Throws<InvalidOperationException>(() => Eval(ab));
+		}
+
+		#endregion
+
+		#region String and Null
+
+		[Test]
+		public void StringPlusNull()
+		{
+			var an = new AddExpression(varA, varNull);
+			Assert.AreEqual("a", Eval(an).AsObject());
+
+			var na = new AddExpression(varNull, varA);
+			Assert.AreEqual("a", Eval(na).AsObject());
+		}
+
+		[Test]
+		public void StringMinusNull()
+		{
+			var an = new SubtractExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new SubtractExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void StringTimesNull()
+		{
+			var an = new MultiplyExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new MultiplyExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void StringDividedByNull()
+		{
+			var an = new DivideExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new DivideExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void StringAndNull()
+		{
+			var an = new BoolAndExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new BoolAndExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void StringOrNull()
+		{
+			var an = new BoolOrExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolOrExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void StringXorNull()
+		{
+			var an = new BoolXorExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new BoolXorExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void StringEqualsNull()
+		{
+			var aa = new EqualsExpression(varA, varA);
+			Assert.AreEqual(true, Eval(aa).AsObject());
+
+			var ae = new EqualsExpression(varA, varEmpty);
+			Assert.AreEqual(false, Eval(ae).AsObject());
+
+			var an = new EqualsExpression(varA, varNull);
+			Assert.AreEqual(false, Eval(an).AsObject());
+
+			var na = new EqualsExpression(varNull, varA);
+			Assert.AreEqual(false, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void StringNotEqualsNull()
+		{
+			var aa = new NotEqualsExpression(varA, varA);
+			Assert.AreEqual(false, Eval(aa).AsObject());
+
+			var ae = new NotEqualsExpression(varA, varEmpty);
+			Assert.AreEqual(true, Eval(ae).AsObject());
+
+			var an = new NotEqualsExpression(varA, varNull);
+			Assert.AreEqual(true, Eval(an).AsObject());
+
+			var na = new NotEqualsExpression(varNull, varA);
+			Assert.AreEqual(true, Eval(na).AsObject());
+		}
+
+		[Test]
+		public void StringGreaterThanNull()
+		{
+			var an = new GreaterThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void StringGreaterThanOrEqualNull()
+		{
+			var an = new GreaterThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new GreaterThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void StringLessThanNull()
+		{
+			var an = new LessThanExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		[Test]
+		public void StringLessThanOrEqualNull()
+		{
+			var an = new LessThanOrEqualExpression(varA, varNull);
+			Assert.Throws<InvalidOperationException>(() => Eval(an));
+
+			var na = new LessThanOrEqualExpression(varNull, varA);
+			Assert.Throws<InvalidOperationException>(() => Eval(na));
+		}
+
+		#endregion
+	}
+}
+
+#endif

--- a/Editor/Tests/Expressions/StringExpressionTest.cs.meta
+++ b/Editor/Tests/Expressions/StringExpressionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c1edd06fd8f46449b66fb6ec62c6d81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tests/Expressions/ValueTest.cs
+++ b/Editor/Tests/Expressions/ValueTest.cs
@@ -26,16 +26,16 @@ namespace Exodrifter.Rumor.Test.Expressions
 		public void ValueConstructor()
 		{
 			var @int = new IntValue(1);
-			Assert.AreEqual(1, @int.AsInt());
+			Assert.AreEqual(1, @int.AsObject());
 
 			var @float = new FloatValue(1.0f);
-			Assert.AreEqual(1.0f, @float.AsFloat());
+			Assert.AreEqual(1.0f, @float.AsObject());
 
 			var @string = new StringValue("1");
-			Assert.AreEqual("1", @string.AsString());
+			Assert.AreEqual("1", @string.AsObject());
 
 			var @bool = new BoolValue(true);
-			Assert.AreEqual(true, @bool.AsBool());
+			Assert.AreEqual(true, @bool.AsObject());
 
 			var @obj = new ObjectValue(null);
 			Assert.AreEqual(null, @obj.AsObject());
@@ -48,29 +48,26 @@ namespace Exodrifter.Rumor.Test.Expressions
 		public void ValueEquality()
 		{
 			var a = new IntValue(1);
-			var b = new IntValue(1);
-			var c = new FloatValue(1.0f);
-			var d = new StringValue("1");
+			var b = new FloatValue(1.0f);
+			var c = new StringValue("1");
 			var e = new BoolValue(true);
 			var f = new ObjectValue(new Foo());
 
 			Assert.AreEqual(a, a);
 			Assert.AreEqual(b, b);
 			Assert.AreEqual(c, c);
-			Assert.AreEqual(d, d);
 			Assert.AreEqual(e, e);
 			Assert.AreEqual(f, f);
 
-			Assert.AreEqual(a, b);
+			Assert.AreNotEqual(a, b);
 			Assert.AreNotEqual(a, c);
-			Assert.AreNotEqual(a, d);
 			Assert.AreNotEqual(a, e);
 			Assert.AreNotEqual(a, f);
-			Assert.AreNotEqual(c, d);
+			Assert.AreNotEqual(b, c);
+			Assert.AreNotEqual(b, e);
+			Assert.AreNotEqual(b, f);
 			Assert.AreNotEqual(c, e);
 			Assert.AreNotEqual(c, f);
-			Assert.AreNotEqual(d, e);
-			Assert.AreNotEqual(d, f);
 			Assert.AreNotEqual(e, f);
 		}
 
@@ -105,7 +102,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(new Foo());
 
-			Assert.AreEqual(2, @int.Add(@int).AsInt());
+			Assert.AreEqual(2, @int.Add(@int).AsObject());
 			Assert.AreEqual(2.0f, @int.Add(@float).AsFloat());
 			Assert.AreEqual("11", @int.Add(@string).AsString());
 			Assert.Catch<InvalidOperationException>(() => @int.Add(@bool));
@@ -148,7 +145,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(new Foo());
 
-			Assert.AreEqual(0, @int.Subtract(@int).AsInt());
+			Assert.AreEqual(0, @int.Subtract(@int).AsObject());
 			Assert.AreEqual(0f, @int.Subtract(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @int.Subtract(@string));
 			Assert.Catch<InvalidOperationException>(() => @int.Subtract(@bool));
@@ -191,7 +188,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(new Foo());
 
-			Assert.AreEqual(1, @int.Multiply(@int).AsInt());
+			Assert.AreEqual(1, @int.Multiply(@int).AsObject());
 			Assert.AreEqual(1f, @int.Multiply(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @int.Multiply(@string));
 			Assert.Catch<InvalidOperationException>(() => @int.Multiply(@bool));
@@ -234,7 +231,7 @@ namespace Exodrifter.Rumor.Test.Expressions
 			var @bool = new BoolValue(true);
 			var @obj = new ObjectValue(new Foo());
 
-			Assert.AreEqual(1, @int.Divide(@int).AsInt());
+			Assert.AreEqual(1, @int.Divide(@int).AsObject());
 			Assert.AreEqual(1f, @int.Divide(@float).AsFloat());
 			Assert.Catch<InvalidOperationException>(() => @int.Divide(@string));
 			Assert.Catch<InvalidOperationException>(() => @int.Divide(@bool));

--- a/Expressions/DotExpression.cs
+++ b/Expressions/DotExpression.cs
@@ -21,8 +21,7 @@ namespace Exodrifter.Rumor.Expressions
 			var l = left.Evaluate(scope, bindings);
 
 			if (l == null || l.AsObject() == null) {
-				throw new NullReferenceException(
-					"Left argument to dot operator is null");
+				return new ObjectValue(null);
 			}
 			if (right == null) {
 				throw new NullReferenceException(

--- a/Expressions/Value/FloatValue.cs
+++ b/Expressions/Value/FloatValue.cs
@@ -73,13 +73,16 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Divide(Value value)
 		{
 			if (value == null) {
-				return new FloatValue(0);
+				throw new DivideByZeroException();
 			}
 			if (value.IsObject() && value.AsObject() == null) {
-				return new FloatValue(0);
+				throw new DivideByZeroException();
 			}
 			if (value.IsInt()) {
 				return new FloatValue(AsFloat() / value.AsInt());
+			}
+			if (value.IsFloat() && value.AsFloat() == 0) {
+				throw new DivideByZeroException();
 			}
 			if (value.IsFloat()) {
 				return new FloatValue(AsFloat() / value.AsFloat());

--- a/Expressions/Value/IntValue.cs
+++ b/Expressions/Value/IntValue.cs
@@ -73,10 +73,10 @@ namespace Exodrifter.Rumor.Expressions
 		public override Value Divide(Value value)
 		{
 			if (value == null) {
-				return new IntValue(0);
+				throw new DivideByZeroException();
 			}
 			if (value.IsObject() && value.AsObject() == null) {
-				return new IntValue(0);
+				throw new DivideByZeroException();
 			}
 			if (value.IsInt()) {
 				return new IntValue(AsInt() / value.AsInt());

--- a/Expressions/Value/ObjectValue.cs
+++ b/Expressions/Value/ObjectValue.cs
@@ -25,6 +25,9 @@ namespace Exodrifter.Rumor.Expressions
 				if (value == null) {
 					return new ObjectValue(null);
 				}
+				if (value.AsObject() == null) {
+					return new ObjectValue(null);
+				}
 				if (value.IsInt()) {
 					return new IntValue(value.AsInt());
 				}
@@ -114,19 +117,19 @@ namespace Exodrifter.Rumor.Expressions
 				return new BoolValue(AsObject() == null);
 			}
 			if (value.IsBool()) {
-				return new BoolValue((AsObject() != null) == value.AsBool());
+				return new BoolValue(false);
 			}
 			else if (value.IsInt()) {
-				return new BoolValue((AsObject() != null) == (value.AsInt() != 0));
+				return new BoolValue(false);
 			}
 			else if (value.IsFloat()) {
-				return new BoolValue((AsObject() != null) == (value.AsFloat() != 0));
+				return new BoolValue(false);
 			}
 			else if (value.IsString()) {
-				return new BoolValue((AsObject() != null) == (value.AsString() != ""));
+				return new BoolValue(false);
 			}
 			else if (value.IsObject()) {
-				return new BoolValue((AsObject() != null) == (value.AsObject() != null));
+				return new BoolValue(AsObject() == value.AsObject());
 			}
 			throw new InvalidOperationException();
 		}

--- a/Expressions/Value/StringValue.cs
+++ b/Expressions/Value/StringValue.cs
@@ -69,27 +69,27 @@ namespace Exodrifter.Rumor.Expressions
 		{
 			if (value == null)
 			{
-				return new BoolValue(AsString() == "");
+				return new BoolValue(false);
 			}
 			if (value.IsObject())
 			{
-				return new BoolValue((AsString() != "") == (value.AsObject() != null));
+				return new BoolValue(false);
 			}
 			if (value.IsInt())
 			{
-				return new BoolValue((AsString() != "") == (value.AsInt() != 0));
+				return new BoolValue(false);
 			}
 			if (value.IsFloat())
 			{
-				return new BoolValue((AsString() != "") == (value.AsFloat() != 0));
+				return new BoolValue(false);
 			}
 			if (value.IsString())
 			{
-				return new BoolValue((AsString() != "") == (value.AsString() != ""));
+				return new BoolValue(AsString() == value.AsString());
 			}
 			if (value.IsBool())
 			{
-				return new BoolValue((AsString() != "") == (value.AsBool()));
+				return new BoolValue(false);
 			}
 			throw new InvalidOperationException();
 		}


### PR DESCRIPTION
For the types `bool`, `int`, `float`, `string`, and `object`, new tests have been added that check what happens when that type and null are on either side of any expression.

In particular, the following problems were fixed:
* Fix `==` expressions almost always returning `true` instead of the correct value
* Fix `.` expressions with `null` on the left side causing an error instead of returning null
* Update test that said using the `.` operator on primitives shouldn't work when it actually does
* Fix not all cases throw a `DivideByZero` exception when dividing by `0` or `null` when they should throw that exception every time
* Fix `null + null` to return `null` instead of throwing `InvalidOperationException`