### PR TITLE
Fix clear command compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix `>=` and `<=` not working due to comparing the wrapper type instead of
   the wrapped values
 * Fix using `!` on a non-null object would throw an exception
+* `clear choices` and `clear dialog` compile instead of throwing a compilation
+  error
 
 ## [2.0.1] - 2018-04-15
 

--- a/Editor/Tests/Language/CompilerTest.cs
+++ b/Editor/Tests/Language/CompilerTest.cs
@@ -163,6 +163,46 @@ namespace Exodrifter.Rumor.Test.Lang
 
 		#endregion
 
+		#region Clear
+
+		/// <summary>
+		/// Checks if clear statements with no argument compile.
+		/// </summary>
+		[Test]
+		public void CompileClearNoArgs()
+		{
+			var nodes = Compiler.Compile("clear");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.IsAssignableFrom<Clear>(nodes[0]);
+			Assert.AreEqual(ClearType.ALL, (nodes[0] as Clear).ClearType);
+		}
+
+		/// <summary>
+		/// Checks if clear statements with the "dialog" argument compile.
+		/// </summary>
+		[Test]
+		public void CompileClearDialog()
+		{
+			var nodes = Compiler.Compile("clear dialog");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.IsAssignableFrom<Clear>(nodes[0]);
+			Assert.AreEqual(ClearType.DIALOG, (nodes[0] as Clear).ClearType);
+		}
+
+		/// <summary>
+		/// Checks if clear statements with the "choices" argument compile.
+		/// </summary>
+		[Test]
+		public void CompileClearChoices()
+		{
+			var nodes = Compiler.Compile("clear choices");
+			Assert.AreEqual(1, nodes.Count);
+			Assert.IsAssignableFrom<Clear>(nodes[0]);
+			Assert.AreEqual(ClearType.CHOICES, (nodes[0] as Clear).ClearType);
+		}
+
+		#endregion
+
 		/// <summary>
 		/// Checks if '$' statements compile.
 		/// <summary>

--- a/Language/Parser.cs
+++ b/Language/Parser.cs
@@ -353,13 +353,16 @@ namespace Exodrifter.Rumor.Language
 		private Clear CompileClear(Reader reader)
 		{
 			var type = ClearType.ALL;
+			reader.Skip();
 
 			if (reader.HasMatch("choices"))
 			{
+				reader.Read("choices".Length);
 				type = ClearType.CHOICES;
 			}
 			else if (reader.HasMatch("dialog"))
 			{
+				reader.Read("dialog".Length);
 				type = ClearType.DIALOG;
 			}
 

--- a/Nodes/Clear.cs
+++ b/Nodes/Clear.cs
@@ -12,7 +12,11 @@ namespace Exodrifter.Rumor.Nodes
 	[Serializable]
 	public sealed class Clear : Node
 	{
-		private ClearType type;
+		private readonly ClearType type;
+		public ClearType ClearType
+		{
+			get { return type; }
+		}
 
 		/// <summary>
 		/// Creates a new Return node.


### PR DESCRIPTION
`clear choices` and `clear dialog` compile instead of throwing an error.