### PR TITLE
Fix scope serialization in .NET 4.x

### DIFF
--- a/Engine/Scope.cs
+++ b/Engine/Scope.cs
@@ -204,18 +204,27 @@ namespace Exodrifter.Rumor.Engine
 
 		#region Serialization
 
+		private List<string> tempKeys;
+		private List<Value> tempValues;
+
 		public Scope(SerializationInfo info, StreamingContext context)
 		{
-			var keys = info.GetValue<List<string>>("keys");
-			var values = info.GetValue<List<Value>>("values");
-
 			vars = new Dictionary<string, Value>();
-			for (int i = 0; i < keys.Count; ++i)
-			{
-				vars.Add(keys[i], values[i]);
-			}
+			tempKeys = info.GetValue<List<string>>("keys");
+			tempValues = info.GetValue<List<Value>>("values");
 
 			DefaultSpeaker = info.GetValue<object>("defaultSpeaker");
+		}
+
+		[OnDeserialized]
+		void OnDeserialized()
+		{
+			for (int i = 0; i < tempKeys.Count; ++i)
+			{
+				vars.Add(tempKeys[i], tempValues[i]);
+			}
+			tempKeys = null;
+			tempValues = null;
 		}
 
 		void ISerializable.GetObjectData


### PR DESCRIPTION
Scope serialization doesn't work when the .NET 4.x runtime is selected. This is because `GetValue` doesn't guarantee that the values are deserialized until the deserialization constructor has exited. Instead,
we need to save the deserialized variables into instance variables, then use them in a method marked with the `OnDeserialized` attribute to repopulate the Dictionary.

The instance variables are then set to `null` to give the garbage collector an opportunity to free up some memory.

Fixes #69.